### PR TITLE
Fix typo in PROVIDER_NAME argument documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Options:
 
 ```
 $ tfupdate provider --help
-Usage: tfupdate provider [options] <PROVIER_NAME> <PATH>
+Usage: tfupdate provider [options] <PROVIDER_NAME> <PATH>
 
 Arguments
-  PROVIER_NAME       A name of provider (e.g. aws, google, azurerm)
+  PROVIDER_NAME      A name of provider (e.g. aws, google, azurerm)
   PATH               A path of file or directory to update
 
 Options:

--- a/command/provider.go
+++ b/command/provider.go
@@ -75,10 +75,10 @@ func (c *ProviderCommand) Run(args []string) int {
 // Help returns long-form help text.
 func (c *ProviderCommand) Help() string {
 	helpText := `
-Usage: tfupdate provider [options] <PROVIER_NAME> <PATH>
+Usage: tfupdate provider [options] <PROVIDER_NAME> <PATH>
 
 Arguments
-  PROVIER_NAME       A name of provider (e.g. aws, google, azurerm)
+  PROVIDER_NAME      A name of provider (e.g. aws, google, azurerm)
   PATH               A path of file or directory to update
 
 Options:


### PR DESCRIPTION
Simple typo fix in the documentation