### PR TITLE
Add module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 ## Features
 
-- Update version constraints of Terraform core and providers
+- Update version constraints of Terraform core, providers, and modules
 - Update all your Terraform configurations recursively under a given directory
 - Get the latest release version automatically from GitHub Release
 - Terraform v0.12+ support
+
+Note: Automatic latest version resolution is not currently supported for modules.
 
 ## Why?
 It is a best practice to break your Terraform configuration and state into small pieces based on the environments and frequency of changes to minimize the impact of an accident.
@@ -136,6 +138,7 @@ $ tfupdate --help
 Usage: tfupdate [--version] [--help] <command> [<args>]
 
 Available commands are:
+    module       Update version constraints for module
     provider     Update version constraints for provider
     release      Get release version information
     terraform    Update version constraints for terraform
@@ -169,6 +172,25 @@ Options:
                      If the version is omitted, the latest version is automatically checked and set.
                      Getting the latest version automatically is supported only for official providers.
                      If you have an unofficial provider, use release latest command.
+  -r  --recursive    Check a directory recursively (default: false)
+  -i  --ignore-path  A regular expression for path to ignore
+                     If you want to ignore multiple directories, set the flag multiple times.
+```
+
+```
+$ tfupdate module --help
+Usage: tfupdate module [options] <MODULE_NAME> <PATH>
+
+Arguments
+  MODULE_NAME        A name of module
+                     e.g.
+                       terraform-aws-modules/vpc/aws
+                       git::https://example.com/vpc.git
+  PATH               A path of file or directory to update
+
+Options:
+  -v  --version      A new version constraint (required)
+                     Automatic latest version resolution is not currently supported for modules.
   -r  --recursive    Check a directory recursively (default: false)
   -i  --ignore-path  A regular expression for path to ignore
                      If you want to ignore multiple directories, set the flag multiple times.

--- a/command/module.go
+++ b/command/module.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/minamijoyo/tfupdate/tfupdate"
+	flag "github.com/spf13/pflag"
+)
+
+// ModuleCommand is a command which update version constraints for module.
+type ModuleCommand struct {
+	Meta
+	name        string
+	version     string
+	path        string
+	recursive   bool
+	ignorePaths []string
+}
+
+// Run runs the procedure of this command.
+func (c *ModuleCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("module", flag.ContinueOnError)
+	cmdFlags.StringVarP(&c.version, "version", "v", "", "A new version constraint")
+	cmdFlags.BoolVarP(&c.recursive, "recursive", "r", false, "Check a directory recursively")
+	cmdFlags.StringArrayVarP(&c.ignorePaths, "ignore-path", "i", []string{}, "A regular expression for path to ignore")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		c.UI.Error(fmt.Sprintf("failed to parse arguments: %s", err))
+		return 1
+	}
+
+	if len(cmdFlags.Args()) != 2 {
+		c.UI.Error(fmt.Sprintf("The command expects 2 arguments, but got %d", len(cmdFlags.Args())))
+		c.UI.Error(c.Help())
+		return 1
+	}
+
+	c.name = cmdFlags.Arg(0)
+	c.path = cmdFlags.Arg(1)
+
+	v := c.version
+	if len(v) == 0 {
+		// For modules, automatic latest version resolution is not simple.
+		// To implement, we will probably need to get information from the Terraform Registry.
+		c.UI.Error("A new version constraint is required. Automatic latest version resolution is not currently supported for modules.")
+		return 1
+	}
+
+	log.Printf("[INFO] Update module %s to %s", c.name, v)
+	option, err := tfupdate.NewOption("module", c.name, v, c.recursive, c.ignorePaths)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	err = tfupdate.UpdateFileOrDir(c.Fs, c.path, option)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+// Help returns long-form help text.
+func (c *ModuleCommand) Help() string {
+	helpText := `
+Usage: tfupdate module [options] <MODULE_NAME> <PATH>
+
+Arguments
+  MODULE_NAME        A name of module
+                     e.g.
+                       terraform-aws-modules/vpc/aws
+                       git::https://example.com/vpc.git
+  PATH               A path of file or directory to update
+
+Options:
+  -v  --version      A new version constraint (required)
+                     Automatic latest version resolution is not currently supported for modules.
+  -r  --recursive    Check a directory recursively (default: false)
+  -i  --ignore-path  A regular expression for path to ignore
+                     If you want to ignore multiple directories, set the flag multiple times.
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis returns one-line help text.
+func (c *ModuleCommand) Synopsis() string {
+	return "Update version constraints for module"
+}

--- a/main.go
+++ b/main.go
@@ -88,6 +88,11 @@ func initCommands() map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"module": func() (cli.Command, error) {
+			return &command.ModuleCommand{
+				Meta: meta,
+			}, nil
+		},
 		"release": func() (cli.Command, error) {
 			return &command.ReleaseCommand{
 				Meta: meta,

--- a/tfupdate/hclwrite.go
+++ b/tfupdate/hclwrite.go
@@ -26,3 +26,17 @@ func allMatchingBlocks(b *hclwrite.Body, typeName string, labels []string) []*hc
 
 	return matched
 }
+
+// allMatchingBlocksByType returns all matching blocks from the body that have the
+// given name or returns an empty list if there is currently no matching block.
+// This method is useful when you want to ignore label differences.
+func allMatchingBlocksByType(b *hclwrite.Body, typeName string) []*hclwrite.Block {
+	var matched []*hclwrite.Block
+	for _, block := range b.Blocks() {
+		if typeName == block.Type() {
+			matched = append(matched, block)
+		}
+	}
+
+	return matched
+}

--- a/tfupdate/module.go
+++ b/tfupdate/module.go
@@ -1,0 +1,69 @@
+package tfupdate
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pkg/errors"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ModuleUpdater is a updater implementation which updates the module version constraint.
+type ModuleUpdater struct {
+	name    string
+	version string
+}
+
+// NewModuleUpdater is a factory method which returns an ModuleUpdater instance.
+func NewModuleUpdater(name string, version string) (Updater, error) {
+	if len(name) == 0 {
+		return nil, errors.Errorf("failed to new module updater. name is required.")
+	}
+
+	if len(version) == 0 {
+		return nil, errors.Errorf("failed to new module updater. version is required.")
+	}
+
+	return &ModuleUpdater{
+		name:    name,
+		version: version,
+	}, nil
+}
+
+// Update updates the module version constraint.
+// Note that this method will rewrite the AST passed as an argument.
+func (u *ModuleUpdater) Update(f *hclwrite.File) error {
+	if err := u.updateModuleBlock(f); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (u *ModuleUpdater) updateModuleBlock(f *hclwrite.File) error {
+	for _, m := range allMatchingBlocksByType(f.Body(), "module") {
+		if s := m.Body().GetAttribute("source"); s != nil {
+			source := parseModuleSorce(s)
+
+			if source == u.name {
+				// set a version to attribute value only if the key exists
+				if m.Body().GetAttribute("version") != nil {
+					m.Body().SetAttributeValue("version", cty.StringVal(u.version))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseModuleSorce(a *hclwrite.Attribute) string {
+	tokens := a.Expr().BuildTokens(nil)
+	if len(tokens) == 3 &&
+		tokens[0].Type == hclsyntax.TokenOQuote &&
+		tokens[1].Type == hclsyntax.TokenQuotedLit &&
+		tokens[2].Type == hclsyntax.TokenCQuote {
+		source := string(tokens[1].Bytes)
+		return source
+	}
+	return ""
+}

--- a/tfupdate/module.go
+++ b/tfupdate/module.go
@@ -1,11 +1,20 @@
 package tfupdate
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 )
+
+// moduleSourceRegexp is a regular expression for module source.
+// This is not a complete module source definition, but it is sufficient to
+// parse version. Note that a git reference can be branch name, so we need to
+// check if it seems to be a version number.
+// https://www.terraform.io/docs/modules/sources.html
+var moduleSourceRegexp = regexp.MustCompile(`(.+)\?ref=v([0-9]+(\.[0-9]+)*(-.*)*)`)
 
 // ModuleUpdater is a updater implementation which updates the module version constraint.
 type ModuleUpdater struct {
@@ -42,13 +51,21 @@ func (u *ModuleUpdater) Update(f *hclwrite.File) error {
 func (u *ModuleUpdater) updateModuleBlock(f *hclwrite.File) error {
 	for _, m := range allMatchingBlocksByType(f.Body(), "module") {
 		if s := m.Body().GetAttribute("source"); s != nil {
-			source := parseModuleSorce(s)
-
-			if source == u.name {
-				// set a version to attribute value only if the key exists
-				if m.Body().GetAttribute("version") != nil {
-					m.Body().SetAttributeValue("version", cty.StringVal(u.version))
+			name, version := parseModuleSource(s)
+			// If this module is a target module
+			if name == u.name {
+				if len(version) == 0 {
+					// The source attribute doesn't have a version number.
+					// Set a version to attribute value only if the version key exists.
+					if m.Body().GetAttribute("version") != nil {
+						m.Body().SetAttributeValue("version", cty.StringVal(u.version))
+					}
+					continue
 				}
+				// The source attribute has a version number.
+				// Update a version reference in the source value.
+				newSourceValue := name + `?ref=v` + u.version
+				m.Body().SetAttributeValue("source", cty.StringVal(newSourceValue))
 			}
 		}
 	}
@@ -56,14 +73,22 @@ func (u *ModuleUpdater) updateModuleBlock(f *hclwrite.File) error {
 	return nil
 }
 
-func parseModuleSorce(a *hclwrite.Attribute) string {
+// parseModuleSource parses module source and returns module name and version.
+func parseModuleSource(a *hclwrite.Attribute) (string, string) {
 	tokens := a.Expr().BuildTokens(nil)
 	if len(tokens) == 3 &&
 		tokens[0].Type == hclsyntax.TokenOQuote &&
 		tokens[1].Type == hclsyntax.TokenQuotedLit &&
 		tokens[2].Type == hclsyntax.TokenCQuote {
 		source := string(tokens[1].Bytes)
-		return source
+		matched := moduleSourceRegexp.FindStringSubmatch(source)
+		if len(matched) == 0 {
+			// no version number
+			return source, ""
+		}
+		name := matched[1]
+		version := matched[2]
+		return name, version
 	}
-	return ""
+	return "", ""
 }

--- a/tfupdate/module_test.go
+++ b/tfupdate/module_test.go
@@ -1,0 +1,164 @@
+package tfupdate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func TestNewModuleUpdater(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		want    Updater
+		ok      bool
+	}{
+		{
+			name:    "terraform-aws-modules/vpc/aws",
+			version: "2.17.0",
+			want: &ModuleUpdater{
+				name:    "terraform-aws-modules/vpc/aws",
+				version: "2.17.0",
+			},
+			ok: true,
+		},
+		{
+			name:    "",
+			version: "2.17.0",
+			want:    nil,
+			ok:      false,
+		},
+		{
+			name:    "terraform-aws-modules/vpc/aws",
+			version: "",
+			want:    nil,
+			ok:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		got, err := NewModuleUpdater(tc.name, tc.version)
+		if tc.ok && err != nil {
+			t.Errorf("NewModuleUpdater() with name = %s, version = %s returns unexpected err: %+v", tc.name, tc.version, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewModuleUpdater() with name = %s, version = %s expects to return an error, but no error", tc.name, tc.version)
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("NewModuleUpdater() with name = %s, version = %s returns %#v, but want = %#v", tc.name, tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestUpdateModule(t *testing.T) {
+	cases := []struct {
+		src     string
+		name    string
+		version string
+		want    string
+		ok      bool
+	}{
+		{
+			src: `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.17.0"
+}
+`,
+			name:    "terraform-aws-modules/vpc/aws",
+			version: "2.18.0",
+			want: `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.18.0"
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+module "vpc1" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.17.0"
+}
+module "vpc2" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.17.0"
+}
+`,
+			name:    "terraform-aws-modules/vpc/aws",
+			version: "2.18.0",
+			want: `
+module "vpc1" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.18.0"
+}
+module "vpc2" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.18.0"
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.17.0"
+}
+`,
+			name:    "terraform-aws-modules/hoge/aws",
+			version: "2.18.0",
+			want: `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.17.0"
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+`,
+			name:    "terraform-aws-modules/vpc/aws",
+			version: "2.18.0",
+			want: `
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+`,
+			ok: true,
+		},
+	}
+
+	for _, tc := range cases {
+		u := &ModuleUpdater{
+			name:    tc.name,
+			version: tc.version,
+		}
+		f, diags := hclwrite.ParseConfig([]byte(tc.src), "", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("unexpected diagnostics: %s", diags)
+		}
+
+		err := u.Update(f)
+		if tc.ok && err != nil {
+			t.Errorf("Update() with src = %s, name = %s, version = %s returns unexpected err: %+v", tc.src, tc.name, tc.version, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("Update() with src = %s, name = %s, version = %s expects to return an error, but no error", tc.src, tc.name, tc.version)
+		}
+
+		got := string(hclwrite.Format(f.BuildTokens(nil).Bytes()))
+		if got != tc.want {
+			t.Errorf("Update() with src = %s, name = %s, version = %s returns %s, but want = %s", tc.src, tc.name, tc.version, got, tc.want)
+		}
+	}
+}

--- a/tfupdate/update.go
+++ b/tfupdate/update.go
@@ -28,7 +28,7 @@ func NewUpdater(o Option) (Updater, error) {
 	case "provider":
 		return NewProviderUpdater(o.name, o.version)
 	case "module":
-		return nil, errors.Errorf("failed to new updater. module is not currently supported.")
+		return NewModuleUpdater(o.name, o.version)
 	default:
 		return nil, errors.Errorf("failed to new updater. unknown type: %s", o.updateType)
 	}

--- a/tfupdate/update_test.go
+++ b/tfupdate/update_test.go
@@ -40,8 +40,11 @@ func TestNewUpdater(t *testing.T) {
 				name:       "terraform-aws-modules/vpc/aws",
 				version:    "2.14.0",
 			},
-			want: nil,
-			ok:   false,
+			want: &ModuleUpdater{
+				name:    "terraform-aws-modules/vpc/aws",
+				version: "2.14.0",
+			},
+			ok: true,
 		},
 		{
 			o: Option{


### PR DESCRIPTION
Add support for updating module version and source reference.

Note: Automatic latest version resolution is not currently supported for modules. It's not so simple. To implement, we will probably need to get information from the Terraform Registry.