### PR TITLE
Fix instruction for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ https://github.com/minamijoyo/tfupdate/releases
 If you have Go 1.13+ development environment:
 
 ```
-$ go get github.com/minamijoyo/tfupdate
+$ git clone https://github.com/minamijoyo/tfupdate
+$ cd tfupdate/
+$ make install
+$ tfupdate --version
 ```
 
 ### Docker


### PR DESCRIPTION
Fixes #5

We cannnot build from source with `go get github.com/minamijoyo/tfupdate`
Because the hcl2 branch in hashicorp/hcl has not been merged into master yet.
I'm not sure this is an issue or a spec of `go get`,
but we need to fix the instruction in README anyway.