### PR TITLE
Add support for GitHub private repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ $ tfupdate release latest terraform-providers/terraform-provider-aws
 2.40.0
 ```
 
+If you want to access private repositories on GitHub, export your access token to the `GITHUB_TOKEN` environment variable.
+
 ## Keep your dependencies up-to-date
 
 If you integrate tfupdate with your favorite CI or job scheduler, you can check the latest release daily and create a Pull Request automatically.

--- a/command/env.go
+++ b/command/env.go
@@ -5,4 +5,7 @@ type Env struct {
 	// GitHubBaseURL is a URL for GtiHub API requests.
 	// Defaults to the public GitHub API.
 	GitHubBaseURL string `envconfig:"GITHUB_BASE_URL" default:"https://api.github.com/"`
+	// GitHubToken is a personal access token for GitHub.
+	// This allows access to a private repository.
+	GitHubToken string `envconfig:"GITHUB_TOKEN"`
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -30,6 +30,7 @@ func newRelease(sourceType string, source string) (release.Release, error) {
 	case "github":
 		config := release.GitHubConfig{
 			BaseURL: env.GitHubBaseURL,
+			Token:   env.GitHubToken,
 		}
 		return release.NewGitHubRelease(source, config)
 	default:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/zclconf/go-cty v1.1.0
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 )
 
 // Fix invalid pseudo-version: revision is longer than canonical (b0274f40d4c7)

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 h1:pE8b58s1HRDMi8RDc79m0HISf9D4TzseP40cEA6IGfs=
+golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/release/github_test.go
+++ b/release/github_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-github/v28/github"
+	"golang.org/x/oauth2"
 )
 
 // GitHubClient is a mock GitHubAPI implementation.
@@ -59,7 +60,7 @@ func TestNewGitHubClient(t *testing.T) {
 		}
 
 		if !tc.ok && err == nil {
-			t.Errorf("NewGitHubClient() with baseURL = %s expect to return an error, but no error", tc.baseURL)
+			t.Errorf("NewGitHubClient() with baseURL = %s expects to return an error, but no error", tc.baseURL)
 		}
 
 		if tc.ok {
@@ -70,6 +71,27 @@ func TestNewGitHubClient(t *testing.T) {
 	}
 }
 
+func TestNewOAuth2Client(t *testing.T) {
+	cases := []struct {
+		token string
+	}{
+		{
+			token: "hoge",
+		},
+	}
+
+	for _, tc := range cases {
+		c := newOAuth2Client(tc.token)
+		trans := c.Transport.(*oauth2.Transport)
+		got, err := trans.Source.Token()
+		if err != nil {
+			t.Fatalf("failed to get a token from OAuth2 client: %s", err)
+		}
+		if got.AccessToken != tc.token {
+			t.Errorf("newOAuth2Client() expects to set a token = %s, but got = %s", tc.token, got.AccessToken)
+		}
+	}
+}
 func TestNewGitHubRelease(t *testing.T) {
 	cases := []struct {
 		source string
@@ -105,7 +127,7 @@ func TestNewGitHubRelease(t *testing.T) {
 		}
 
 		if !tc.ok && err == nil {
-			t.Errorf("NewGitHubRelease() with source = %s, api = %#v expect to return an error, but no error", tc.source, tc.api)
+			t.Errorf("NewGitHubRelease() with source = %s, api = %#v expects to return an error, but no error", tc.source, tc.api)
 		}
 
 		if tc.ok {
@@ -183,7 +205,7 @@ func TestGitHubReleaseLatest(t *testing.T) {
 		}
 
 		if !tc.ok && err == nil {
-			t.Errorf("(*GitHubRelease).Latest() with r = %s expect to return an error, but no error", spew.Sdump(r))
+			t.Errorf("(*GitHubRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
 		}
 
 		if got != tc.want {


### PR DESCRIPTION
You can now get the latest release version from GitHub private repositories.

If you want to access private repositories on GitHub, export your access token to the `GITHUB_TOKEN` environment variable.