### PR TITLE
Add support for GitLab projects to release latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - Update version constraints of Terraform core, providers, and modules
 - Update all your Terraform configurations recursively under a given directory
-- Get the latest release version from GitHub Release
+- Get the latest release version from a GitHub or GitLab Release
 - Terraform v0.12+ support
 
 If you integrate tfupdate with your favorite CI or job scheduler, you can check the latest release daily and create a Pull Request automatically.
@@ -214,13 +214,15 @@ Usage: tfupdate release latest [options] <SOURCE>
 Arguments
   SOURCE             A path of release data source.
                      Valid format depends on --source-type option.
-                     - github:
+                       - github or gitlab:
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
 
 Options:
   -s  --source-type  A type of release data source.
-                     Valid value is only github. (default: github)
+                     Valid values are
+                       - github (default)
+                       - gitlab
 ```
 
 ```
@@ -229,6 +231,8 @@ $ tfupdate release latest terraform-providers/terraform-provider-aws
 ```
 
 If you want to access private repositories on GitHub, export your access token to the `GITHUB_TOKEN` environment variable.
+
+If you want to access public or private repositories on GitLab, export your access token with api permissions to the `GITLAB_TOKEN` environment variable. If you are using an instance that is not `https://gitlab.com`, set the correct base URL to the `GITLAB_BASE_URL` environment variable (defaults to `https://gitlab.com/api/v4/`).
 
 ## Keep your dependencies up-to-date
 

--- a/command/env.go
+++ b/command/env.go
@@ -8,4 +8,10 @@ type Env struct {
 	// GitHubToken is a personal access token for GitHub.
 	// This allows access to a private repository.
 	GitHubToken string `envconfig:"GITHUB_TOKEN"`
+	// GitLabBaseURL is a URL for GitLab API requests.
+	// Defaults to the public GitLab API.
+	GitLabBaseURL string `envconfig:"GITLAB_BASE_URL" default:"https://gitlab.com/api/v4/"`
+	// GitLabToken is a personal access token for GitLab.
+	// This is needed for public and private projects on all instances.
+	GitLabToken string `envconfig:"GITLAB_TOKEN"`
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -33,6 +33,12 @@ func newRelease(sourceType string, source string) (release.Release, error) {
 			Token:   env.GitHubToken,
 		}
 		return release.NewGitHubRelease(source, config)
+	case "gitlab":
+		config := release.GitLabConfig{
+			BaseURL: env.GitLabBaseURL,
+			Token:   env.GitLabToken,
+		}
+		return release.NewGitLabRelease(source, config)
 	default:
 		return nil, fmt.Errorf("failed to new release data source. unknown type: %s", sourceType)
 	}

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -38,6 +39,22 @@ func (c *ReleaseLatestCommand) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
+	// else if GitLab (flag?)
+	token := os.Getenv("GITLAB_API_TOKEN")
+	if token == "" {
+		c.UI.Error(fmt.Sprintf("Could not set GitLab API token from env var GITLAB_API_TOKEN."))
+		c.UI.Error(c.Help())
+		return 1
+	}
+	// ok: create gitlabrelease
+	r, err = release.NewGitLabRelease(owner, repo, token)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	// if custom url (flag) url = ...
+	//r.SetGitLabURL(url)
+	// end gitlab if
 
 	v, err := r.Latest(context.Background())
 	if err != nil {

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -39,22 +38,6 @@ func (c *ReleaseLatestCommand) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
-	// else if GitLab (flag?)
-	token := os.Getenv("GITLAB_API_TOKEN")
-	if token == "" {
-		c.UI.Error(fmt.Sprintf("Could not set GitLab API token from env var GITLAB_API_TOKEN."))
-		c.UI.Error(c.Help())
-		return 1
-	}
-	// ok: create gitlabrelease
-	r, err = release.NewGitLabRelease(owner, repo, token)
-	if err != nil {
-		c.UI.Error(err.Error())
-		return 1
-	}
-	// if custom url (flag) url = ...
-	//r.SetGitLabURL(url)
-	// end gitlab if
 
 	v, err := r.Latest(context.Background())
 	if err != nil {
@@ -74,13 +57,15 @@ Usage: tfupdate release latest [options] <SOURCE>
 Arguments
   SOURCE             A path of release data source.
                      Valid format depends on --source-type option.
-                     - github:
+                       - github or gitlab:
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
 
 Options:
   -s  --source-type  A type of release data source.
-                     Valid value is only github. (default: github)
+                     Valid values are
+                       - github (default)
+                       - gitlab
 `
 	return strings.TrimSpace(helpText)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/pflag v1.0.5
+	github.com/xanzy/go-gitlab v0.20.1
 	github.com/zclconf/go-cty v1.1.0
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -22,6 +22,11 @@ func NewGitLabRelease(owner string, project string, token string) (Release, erro
 	}, nil
 }
 
+// SetGitLabURL sets a custom GitLab endpoint
+func (r *GitLabRelease) SetGitLabURL(url string) {
+	r.client.SetBaseURL(url)
+}
+
 // Latest returns a latest version.
 func (r *GitLabRelease) Latest() (string, error) {
 	opt := &gitlab.ListReleasesOptions{}

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -63,6 +63,9 @@ func (c *GitLabClient) ProjectGetLatestRelease(ctx context.Context, owner, proje
 	if err != nil {
 		return nil, nil, err
 	}
+	if len(releases) == 0 {
+		return nil, nil, fmt.Errorf("no releases found for project")
+	}
 	latest := releases[0]
 	return latest, response, err
 }

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -24,15 +24,15 @@ func NewGitLabRelease(owner string, project string, token string) (Release, erro
 
 // Latest returns a latest version.
 func (r *GitLabRelease) Latest() (string, error) {
-  opt := &gitlab.ListReleasesOptions{}
-  releases, _, err := r.client.Releases.ListReleases(1, opt)
+	opt := &gitlab.ListReleasesOptions{}
+	releases, _, err := r.client.Releases.ListReleases(1, opt)
 
 	if err != nil {
 		return "", fmt.Errorf("failed to get the releases from %s/%s: %s", r.owner, r.project, err)
 	}
 
-  // Get latest release
-  latest := releases[0]
+	// Get latest release
+	latest := releases[0]
 
 	// Use TagName because some releases do not have Name.
 	tagName := latest.TagName

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -1,0 +1,46 @@
+package release
+
+import (
+	"fmt"
+
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+// GitLabRelease is a release implementation which provides version information with GitLab Release.
+type GitLabRelease struct {
+	client  *gitlab.Client
+	owner   string
+	project string
+}
+
+// NewGitLabRelease is a factory method which returns an GitLabRelease instance.
+func NewGitLabRelease(owner string, project string, token string) (Release, error) {
+	return &GitLabRelease{
+		client:  gitlab.NewClient(nil, token),
+		owner:   owner,
+		project: project,
+	}, nil
+}
+
+// Latest returns a latest version.
+func (r *GitLabRelease) Latest() (string, error) {
+  opt := &gitlab.ListReleasesOptions{}
+  releases, _, err := r.client.Releases.ListReleases(1, opt)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get the releases from %s/%s: %s", r.owner, r.project, err)
+	}
+
+  // Get latest release
+  latest := releases[0]
+
+	// Use TagName because some releases do not have Name.
+	tagName := latest.TagName
+
+	// if a tagName starts with `v`, remove it.
+	if tagName[0] == 'v' {
+		return tagName[1:], nil
+	}
+
+	return tagName, nil
+}

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -3,9 +3,10 @@ package release
 import (
 	"context"
 	"fmt"
-	"github.com/xanzy/go-gitlab"
 	"net/url"
 	"strings"
+
+	"github.com/xanzy/go-gitlab"
 )
 
 // GitLabAPI is an interface which calls GitLab API.

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -58,7 +58,7 @@ func NewGitLabClient(config GitLabConfig) (*GitLabClient, error) {
 // ProjectGetLatestRelease fetches the latest published release for the project.
 func (c *GitLabClient) ProjectGetLatestRelease(ctx context.Context, owner, project string) (*gitlab.Release, *gitlab.Response, error) {
 	opt := &gitlab.ListReleasesOptions{}
-	releases, response, err := c.client.Releases.ListReleases(owner+"/"+project, opt)
+	releases, response, err := c.client.Releases.ListReleases(owner+"/"+project, opt, gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -38,7 +38,7 @@ type GitLabClient struct {
 // NewGitLabClient returns a real GitLab instance.
 func NewGitLabClient(config GitLabConfig) (*GitLabClient, error) {
 	if len(config.Token) == 0 {
-		return nil, fmt.Errorf("failed to get personal access token")
+		return nil, fmt.Errorf("failed to get personal access token (env: GITLAB_TOKEN)")
 	}
 	c := gitlab.NewClient(nil, config.Token)
 

--- a/release/gitlab_test.go
+++ b/release/gitlab_test.go
@@ -93,6 +93,13 @@ func TestNewGitLabRelease(t *testing.T) {
 			project: "",
 			ok:      false,
 		},
+		{
+			source:  "gitlab-org/gitlab",
+			api:     nil,
+			owner:   "gitlab-org",
+			project: "gitlab",
+			ok:      false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/release/gitlab_test.go
+++ b/release/gitlab_test.go
@@ -1,0 +1,194 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/xanzy/go-gitlab"
+)
+
+// GitLabClient is a mock GitLabAPI implementation.
+type mockGitLabClient struct {
+	projectRelease *gitlab.Release
+	response       *gitlab.Response
+	err            error
+}
+
+func (c *mockGitLabClient) ProjectGetLatestRelease(ctx context.Context, owner, project string) (*gitlab.Release, *gitlab.Response, error) {
+	return c.projectRelease, c.response, c.err
+}
+
+func TestNewGitLabClient(t *testing.T) {
+	cases := []struct {
+		baseURL string
+		want    string
+		ok      bool
+	}{
+		{
+			baseURL: "",
+			want:    "https://gitlab.com/api/v4/",
+			ok:      true,
+		},
+		{
+			baseURL: "https://gitlab.com/api/v4/",
+			want:    "https://gitlab.com/api/v4/",
+			ok:      true,
+		},
+		{
+			baseURL: "http://localhost/api/v4/",
+			want:    "http://localhost/api/v4/",
+			ok:      true,
+		},
+		{
+			baseURL: `https://gitlab\.com/api/v4/`,
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		config := GitLabConfig{
+			BaseURL: tc.baseURL,
+			Token:   "dummy_token",
+		}
+		got, err := NewGitLabClient(config)
+
+		if tc.ok && err != nil {
+			t.Errorf("NewGitLabClient() with baseURL = %s returns unexpected err: %s", tc.baseURL, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewGitLabClient() with baseURL = %s expects to return an error, but no error", tc.baseURL)
+		}
+
+		if tc.ok {
+			if got.client.BaseURL().String() != tc.want {
+				t.Errorf("NewGitLabClient() with baseURL = %s returns %s, but want %s", tc.baseURL, got.client.BaseURL().String(), tc.want)
+			}
+		}
+	}
+}
+
+func TestNewGitLabRelease(t *testing.T) {
+	cases := []struct {
+		source  string
+		api     GitLabAPI
+		owner   string
+		project string
+		ok      bool
+	}{
+		{
+			source:  "gitlab-org/gitlab",
+			api:     &mockGitLabClient{},
+			owner:   "gitlab-org",
+			project: "gitlab",
+			ok:      true,
+		},
+		{
+			source:  "gitlab",
+			api:     &mockGitLabClient{},
+			owner:   "",
+			project: "",
+			ok:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		config := GitLabConfig{
+			api: tc.api,
+		}
+		got, err := NewGitLabRelease(tc.source, config)
+
+		if tc.ok && err != nil {
+			t.Errorf("NewGitLabRelease() with source = %s, api = %#v returns unexpected err: %s", tc.source, tc.api, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewGitLabRelease() with source = %s, api = %#v expects to return an error, but no error", tc.source, tc.api)
+		}
+
+		if tc.ok {
+			r := got
+
+			if r.api != tc.api {
+				t.Errorf("NewGitLabRelease() with source = %s, api = %#v sets api = %#v, but want %s", tc.source, tc.api, r.api, tc.api)
+			}
+
+			if !(r.owner == tc.owner && r.project == tc.project) {
+				t.Errorf("NewGitLabRelease() with source = %s, api = %#v returns (%s, %s), but want (%s, %s)", tc.source, tc.api, r.owner, r.project, tc.owner, tc.project)
+			}
+		}
+	}
+}
+
+func TestGitLabReleaseLatest(t *testing.T) {
+	tagv010 := "v0.1.0"
+	tag010 := "0.1.0"
+	cases := []struct {
+		client *mockGitLabClient
+		want   string
+		ok     bool
+	}{
+		{
+			client: &mockGitLabClient{
+				projectRelease: &gitlab.Release{
+					TagName: tagv010,
+				},
+				response: &gitlab.Response{},
+				err:      nil,
+			},
+			want: "0.1.0",
+			ok:   true,
+		},
+		{
+			client: &mockGitLabClient{
+				projectRelease: &gitlab.Release{
+					TagName: tag010,
+				},
+				response: &gitlab.Response{},
+				err:      nil,
+			},
+			want: "0.1.0",
+			ok:   true,
+		},
+		{
+			client: &mockGitLabClient{
+				projectRelease: nil,
+				response:       &gitlab.Response{},
+				// Actual error response type is *gitlab.ErrorResponse,
+				// but we are not interested in the internal structure.
+				err: errors.New(`GET https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab/releases: 404 Not Found []`),
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	source := "gitlab-org/gitlab"
+	for _, tc := range cases {
+		// Set a mock client
+		config := GitLabConfig{
+			api: tc.client,
+		}
+		r, err := NewGitLabRelease(source, config)
+		if err != nil {
+			t.Fatalf("failed to NewGitLabRelease(%s, %#v): %s", source, config, err)
+		}
+
+		got, err := r.Latest(context.Background())
+
+		if tc.ok && err != nil {
+			t.Errorf("(*GitLabRelease).Latest() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("(*GitLabRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
+		}
+
+		if got != tc.want {
+			t.Errorf("(*GitLabRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
This implements functionality as requested in #3.

It allows running the `tfupdate release latest -s gitlab <owner>/<project>` command to return the latest release from a GitLab project (repository), both private and public projects.

`GITLAB_TOKEN` is used for the personal access token (this is needed to use the GitLab API for all types of projects). `GITLAB_BASE_URL` is used for api url (`https://gitlab.com/api/v4/` as default value).

It is built with a similar implementation as for GitHub, so the code is rather similar, but with using the [go-gitlab](https://godoc.org/github.com/xanzy/go-gitlab) package.

It works now (`make check` (including tests) and run binary) with some simple tests against projects on a private GitLab instance, but probably has some blind spots.. Comments and suggestions are very welcome.

Merry christmas :santa: 