### PR TITLE
Add support for Terraform Registry Module as a release data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - Update version constraints of Terraform core, providers, and modules
 - Update all your Terraform configurations recursively under a given directory
-- Get the latest release version from a GitHub, GitLab, or Terraform Registry
+- Get the latest release version from the GitHub, GitLab, or Terraform Registry
 - Terraform v0.12+ support
 
 If you integrate tfupdate with your favorite CI or job scheduler, you can check the latest release daily and create a Pull Request automatically.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - Update version constraints of Terraform core, providers, and modules
 - Update all your Terraform configurations recursively under a given directory
-- Get the latest release version from a GitHub or GitLab Release
+- Get the latest release version from a GitHub, GitLab, or Terraform Registry
 - Terraform v0.12+ support
 
 If you integrate tfupdate with your favorite CI or job scheduler, you can check the latest release daily and create a Pull Request automatically.
@@ -207,7 +207,9 @@ Usage: tfupdate release <subcommand> [options] [args]
 
 Subcommands:
     latest    Get the latest release version
+```
 
+```
 $ tfupdate release latest --help
 Usage: tfupdate release latest [options] <SOURCE>
 
@@ -217,12 +219,16 @@ Arguments
                        - github or gitlab:
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
+                      - tfregistryModule
+                         namespace/name/provider
+                         e.g. terraform-aws-modules/vpc/aws
 
 Options:
   -s  --source-type  A type of release data source.
                      Valid values are
                        - github (default)
                        - gitlab
+                       - tfregistryModule
 ```
 
 ```

--- a/command/meta.go
+++ b/command/meta.go
@@ -39,6 +39,9 @@ func newRelease(sourceType string, source string) (release.Release, error) {
 			Token:   env.GitLabToken,
 		}
 		return release.NewGitLabRelease(source, config)
+	case "tfregistryModule":
+		config := release.TFRegistryConfig{}
+		return release.NewTFRegistryModuleRelease(source, config)
 	default:
 		return nil, fmt.Errorf("failed to new release data source. unknown type: %s", sourceType)
 	}

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -60,12 +60,16 @@ Arguments
                        - github or gitlab:
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
+                      - tfregistryModule
+                         namespace/name/provider
+                         e.g. terraform-aws-modules/vpc/aws
 
 Options:
   -s  --source-type  A type of release data source.
                      Valid values are
                        - github (default)
                        - gitlab
+                       - tfregistryModule
 `
 	return strings.TrimSpace(helpText)
 }

--- a/release/github.go
+++ b/release/github.go
@@ -25,7 +25,7 @@ type GitHubConfig struct {
 	// It can be replaced for testing.
 	api GitHubAPI
 
-	// BaseURL is a URL for GtiHub API requests.
+	// BaseURL is a URL for GitHub API requests.
 	// Defaults to the public GitHub API.
 	// This looks like the GitHub Enterprise support, but currently for testing purposes only.
 	// The GitHub Enterprise is not supported yet.

--- a/release/github_test.go
+++ b/release/github_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// GitHubClient is a mock GitHubAPI implementation.
+// mockGitHubClient is a mock GitHubAPI implementation.
 type mockGitHubClient struct {
 	repositoryRelease *github.RepositoryRelease
 	response          *github.Response

--- a/release/gitlab_test.go
+++ b/release/gitlab_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-// GitLabClient is a mock GitLabAPI implementation.
+// mockGitLabClient is a mock GitLabAPI implementation.
 type mockGitLabClient struct {
 	projectRelease *gitlab.Release
 	response       *gitlab.Response

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -61,7 +61,7 @@ func (c *TFRegistryClient) ModuleLatestForProvider(ctx context.Context, req *tfr
 
 // TFRegistryModuleRelease is a release implementation which provides version information with TFRegistryModule Release.
 type TFRegistryModuleRelease struct {
-	// api is an instance of TFRegistryModuleAPI interface.
+	// api is an instance of TFRegistryAPI interface.
 	// It can be replaced for testing.
 	api TFRegistryAPI
 

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -1,0 +1,119 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/minamijoyo/tfupdate/tfregistry"
+)
+
+// TFRegistryAPI is an interface which calls Terraform Registry API.
+// This abstraction layer is needed for testing with mock.
+type TFRegistryAPI interface {
+	// ModuleLatestForProvider returns the latest version of a module for a single provider.
+	// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+	ModuleLatestForProvider(ctx context.Context, req *tfregistry.ModuleLatestForProviderRequest) (*tfregistry.ModuleLatestForProviderResponse, error)
+}
+
+// TFRegistryConfig is a set of configurations for TFRegistryModuleRelease and TFRegistryProviderRelease.
+type TFRegistryConfig struct {
+	// api is an instance of TFRegistryAPI interface.
+	// It can be replaced for testing.
+	api TFRegistryAPI
+
+	// BaseURL is a URL for Terraform Registry API requests.
+	// Defaults to the public Terraform Registry API.
+	// This looks like the Terraform Cloud support, but currently for testing purposes only.
+	// The Terraform Cloud is not supported yet.
+	// BaseURL should always be specified with a trailing slash.
+	BaseURL string
+}
+
+// TFRegistryClient is a real TFRegistryAPI implementation.
+type TFRegistryClient struct {
+	client *tfregistry.Client
+}
+
+// NewTFRegistryClient returns a real TFRegistryClient instance.
+func NewTFRegistryClient(config TFRegistryConfig) (*TFRegistryClient, error) {
+	c := tfregistry.NewClient(nil)
+
+	if len(config.BaseURL) != 0 {
+		baseURL, err := url.Parse(config.BaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tfregistry base url: %s", err)
+		}
+		c.BaseURL = baseURL
+	}
+
+	return &TFRegistryClient{
+		client: c,
+	}, nil
+}
+
+// ModuleLatestForProvider returns the latest version of a module for a single provider.
+// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+func (c *TFRegistryClient) ModuleLatestForProvider(ctx context.Context, req *tfregistry.ModuleLatestForProviderRequest) (*tfregistry.ModuleLatestForProviderResponse, error) {
+	return c.client.ModuleLatestForProvider(ctx, req)
+}
+
+// TFRegistryModuleRelease is a release implementation which provides version information with TFRegistryModule Release.
+type TFRegistryModuleRelease struct {
+	// api is an instance of TFRegistryModuleAPI interface.
+	// It can be replaced for testing.
+	api TFRegistryAPI
+
+	// namespace is a user name which owns the module.
+	namespace string
+
+	// name is a name of the module.
+	name string
+
+	// provider is a name of the provider.
+	provider string
+}
+
+// NewTFRegistryModuleRelease is a factory method which returns an TFRegistryModuleRelease instance.
+func NewTFRegistryModuleRelease(source string, config TFRegistryConfig) (Release, error) {
+	s := strings.SplitN(source, "/", 3)
+	if len(s) != 3 {
+		return nil, fmt.Errorf("failed to parse source: %s", source)
+	}
+
+	// If config.api is not set, create a default TFRegistryClient
+	var api TFRegistryAPI
+	if config.api == nil {
+		var err error
+		api, err = NewTFRegistryClient(config)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		api = config.api
+	}
+
+	return &TFRegistryModuleRelease{
+		api:       api,
+		namespace: s[0],
+		name:      s[1],
+		provider:  s[2],
+	}, nil
+}
+
+// Latest returns a latest version.
+func (r *TFRegistryModuleRelease) Latest(ctx context.Context) (string, error) {
+	req := &tfregistry.ModuleLatestForProviderRequest{
+		Namespace: r.namespace,
+		Name:      r.name,
+		Provider:  r.provider,
+	}
+	release, err := r.api.ModuleLatestForProvider(ctx, req)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get the latest release for %s/%s/%s: %s", r.namespace, r.name, r.provider, err)
+	}
+
+	return release.Version, nil
+}

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -143,7 +143,7 @@ func TestTFRegistryModuleReleaseLatest(t *testing.T) {
 		{
 			client: &mockTFRegistryClient{
 				moduleRes: nil,
-				err:       errors.New(`{"errors":["Not Found"]}`),
+				err:       errors.New(`unexpected HTTP Status Code: 404`),
 			},
 			want: "",
 			ok:   false,

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
-// TFRegistryClient is a mock TFRegistryAPI implementation.
+// mockTFRegistryClient is a mock TFRegistryAPI implementation.
 type mockTFRegistryClient struct {
 	moduleRes *tfregistry.ModuleLatestForProviderResponse
 	err       error

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -1,0 +1,178 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/minamijoyo/tfupdate/tfregistry"
+)
+
+// TFRegistryClient is a mock TFRegistryAPI implementation.
+type mockTFRegistryClient struct {
+	moduleRes *tfregistry.ModuleLatestForProviderResponse
+	err       error
+}
+
+func (c *mockTFRegistryClient) ModuleLatestForProvider(ctx context.Context, req *tfregistry.ModuleLatestForProviderRequest) (*tfregistry.ModuleLatestForProviderResponse, error) {
+	return c.moduleRes, c.err
+}
+
+func TestNewTFRegistryClient(t *testing.T) {
+	cases := []struct {
+		baseURL string
+		want    string
+		ok      bool
+	}{
+		{
+			baseURL: "",
+			want:    "https://registry.terraform.io/",
+			ok:      true,
+		},
+		{
+			baseURL: "https://registry.terraform.io/",
+			want:    "https://registry.terraform.io/",
+			ok:      true,
+		},
+		{
+			baseURL: "http://localhost/",
+			want:    "http://localhost/",
+			ok:      true,
+		},
+		{
+			baseURL: `https://registry\.terraform.io/`,
+			want:    "",
+			ok:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		config := TFRegistryConfig{
+			BaseURL: tc.baseURL,
+		}
+		got, err := NewTFRegistryClient(config)
+
+		if tc.ok && err != nil {
+			t.Errorf("NewTFRegistryClient() with baseURL = %s returns unexpected err: %s", tc.baseURL, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewTFRegistryClient() with baseURL = %s expects to return an error, but no error", tc.baseURL)
+		}
+
+		if tc.ok {
+			if got.client.BaseURL.String() != tc.want {
+				t.Errorf("NewTFRegistryClient() with baseURL = %s returns %s, but want %s", tc.baseURL, got.client.BaseURL.String(), tc.want)
+			}
+		}
+	}
+}
+
+func TestNewTFRegistryModuleRelease(t *testing.T) {
+	cases := []struct {
+		source    string
+		api       TFRegistryAPI
+		namespace string
+		name      string
+		provider  string
+		ok        bool
+	}{
+		{
+			source:    "hoge/fuga/piyo",
+			api:       &mockTFRegistryClient{},
+			namespace: "hoge",
+			name:      "fuga",
+			provider:  "piyo",
+			ok:        true,
+		},
+		{
+			source:    "hoge",
+			api:       &mockTFRegistryClient{},
+			namespace: "",
+			name:      "",
+			provider:  "",
+			ok:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		config := TFRegistryConfig{
+			api: tc.api,
+		}
+		got, err := NewTFRegistryModuleRelease(tc.source, config)
+
+		if tc.ok && err != nil {
+			t.Errorf("NewTFRegistryModuleRelease() with source = %s, api = %#v returns unexpected err: %s", tc.source, tc.api, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewTFRegistryModuleRelease() with source = %s, api = %#v expects to return an error, but no error", tc.source, tc.api)
+		}
+
+		if tc.ok {
+			r := got.(*TFRegistryModuleRelease)
+
+			if r.api != tc.api {
+				t.Errorf("NewTFRegistryModuleRelease() with source = %s, api = %#v sets api = %#v, but want %s", tc.source, tc.api, r.api, tc.api)
+			}
+
+			if !(r.namespace == tc.namespace && r.name == tc.name && r.provider == tc.provider) {
+				t.Errorf("NewTFRegistryModuleRelease() with source = %s, api = %#v returns (%s, %s, %s), but want (%s, %s, %s)", tc.source, tc.api, r.namespace, r.name, r.provider, tc.namespace, tc.name, tc.provider)
+			}
+		}
+	}
+}
+
+func TestTFRegistryModuleReleaseLatest(t *testing.T) {
+	cases := []struct {
+		client *mockTFRegistryClient
+		want   string
+		ok     bool
+	}{
+		{
+			client: &mockTFRegistryClient{
+				moduleRes: &tfregistry.ModuleLatestForProviderResponse{
+					Version: "0.1.0",
+				},
+				err: nil,
+			},
+			want: "0.1.0",
+			ok:   true,
+		},
+		{
+			client: &mockTFRegistryClient{
+				moduleRes: nil,
+				err:       errors.New(`{"errors":["Not Found"]}`),
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	source := "hoge/fuga/piyo"
+	for _, tc := range cases {
+		// Set a mock client
+		config := TFRegistryConfig{
+			api: tc.client,
+		}
+		r, err := NewTFRegistryModuleRelease(source, config)
+		if err != nil {
+			t.Fatalf("failed to NewTFRegistryModuleRelease(%s, %#v): %s", source, config, err)
+		}
+
+		got, err := r.Latest(context.Background())
+
+		if tc.ok && err != nil {
+			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
+		}
+
+		if got != tc.want {
+			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
+		}
+	}
+}

--- a/tfregistry/client.go
+++ b/tfregistry/client.go
@@ -1,0 +1,71 @@
+package tfregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+// To avoid depending on a specific version of Terraform,
+// we implement a pure Terraform Registry API client.
+// https://www.terraform.io/docs/registry/api.html
+//
+// Currently only the official public registry is supported.
+// There are other APIs and request/response fields,
+// but we define only the ones we need here to keep it simple.
+
+const (
+	// The public Terraform Registry API endpoint.
+	defaultBaseURL = "https://registry.terraform.io/"
+)
+
+// Client manages communication with the Terraform Registry API.
+type Client struct {
+	// httpClient is a http client which communicates with the API.
+	httpClient *http.Client
+	// BaseURL is a base url for API requests. Defaults to the public Terraform Registry API.
+	BaseURL *url.URL
+}
+
+// NewClient returns a new Client instance.
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	baseURL, _ := url.Parse(defaultBaseURL)
+	c := &Client{httpClient: httpClient, BaseURL: baseURL}
+	return c
+}
+
+// newRequest builds a http Request instance.
+func (c *Client) newRequest(ctx context.Context, method string, subPath string, body io.Reader) (*http.Request, error) {
+	endpointURL := *c.BaseURL
+	endpointURL.Path = path.Join(c.BaseURL.Path, subPath)
+
+	req, err := http.NewRequest(method, endpointURL.String(), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP request: err = %s, method = %s, endpointURL = %s, body = %#v", err, method, endpointURL.String(), body)
+	}
+
+	req = req.WithContext(ctx)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+// decodeBody decodes a raw body data into a specific response type structure.
+func decodeBody(resp *http.Response, out interface{}) error {
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	err := decoder.Decode(out)
+	if err != nil {
+		return fmt.Errorf("failed to decode response: err = %s, resp = %#v", err, resp)
+	}
+
+	return nil
+}

--- a/tfregistry/mock.go
+++ b/tfregistry/mock.go
@@ -1,0 +1,23 @@
+package tfregistry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+// newMockServer returns a new mock server for testing.
+func newMockServer() (*http.ServeMux, *url.URL) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	mockServerURL, _ := url.Parse(server.URL)
+	return mux, mockServerURL
+}
+
+// newTestClient returns a new client for testing.
+func newTestClient(mockServerURL *url.URL) *Client {
+	httpClient := &http.Client{}
+	c := NewClient(httpClient)
+	c.BaseURL = mockServerURL
+	return c
+}

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -44,6 +44,16 @@ type ModuleLatestForProviderResponse struct {
 // ModuleLatestForProvider returns the latest version of a module for a single provider.
 // https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
 func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error) {
+	if len(req.Namespace) == 0 {
+		return nil, fmt.Errorf("Invalid request. Namespace is required. req = %#v", req)
+	}
+	if len(req.Name) == 0 {
+		return nil, fmt.Errorf("Invalid request. Name is required. req = %#v", req)
+	}
+	if len(req.Provider) == 0 {
+		return nil, fmt.Errorf("Invalid request. Provider is required. req = %#v", req)
+	}
+
 	subPath := fmt.Sprintf("%s%s/%s/%s", moduleV1Service, req.Namespace, req.Name, req.Provider)
 
 	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -7,8 +7,13 @@ import (
 
 const (
 	// moduleV1Service is a sub path of module v1 service endpoint.
-	// The service discovery is not implemented for now.
-	moduleV1Service = "v1/modules"
+	// The service discovery protocol is not implemented for now.
+	// https://www.terraform.io/docs/internals/remote-service-discovery.html
+	//
+	// Include slashes for later implementation of service discovery.
+	// curl https://registry.terraform.io/.well-known/terraform.json
+	// {"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}
+	moduleV1Service = "/v1/modules/"
 )
 
 // ModuleV1API is an interface for the module v1 service.
@@ -39,7 +44,7 @@ type ModuleLatestForProviderResponse struct {
 // ModuleLatestForProvider returns the latest version of a module for a single provider.
 // https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
 func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error) {
-	subPath := fmt.Sprintf("/%s/%s/%s/%s", moduleV1Service, req.Namespace, req.Name, req.Provider)
+	subPath := fmt.Sprintf("%s%s/%s/%s", moduleV1Service, req.Namespace, req.Name, req.Provider)
 
 	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)
 	if err != nil {

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -52,7 +52,7 @@ func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestF
 	}
 
 	if httpResponse.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected HTTP Status Code: %d, response: %#v", httpResponse.StatusCode, httpResponse)
+		return nil, fmt.Errorf("unexpected HTTP Status Code: %d", httpResponse.StatusCode)
 	}
 
 	var res ModuleLatestForProviderResponse

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -21,11 +21,11 @@ type ModuleV1API interface {
 // ModuleLatestForProviderRequest is a request parameter for ModuleLatestForProvider().
 // https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
 type ModuleLatestForProviderRequest struct {
-	// Namespace is the user name which owns the module.
+	// Namespace is a user name which owns the module.
 	Namespace string `json:"namespace"`
-	// Name is the name of the module.
+	// Name is a name of the module.
 	Name string `json:"name"`
-	// Provider is the name of the provider.
+	// Provider is a name of the provider.
 	Provider string `json:"provider"`
 }
 

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -1,0 +1,64 @@
+package tfregistry
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// moduleV1Service is a sub path of module v1 service endpoint.
+	// The service discovery is not implemented for now.
+	moduleV1Service = "v1/modules"
+)
+
+// ModuleV1API is an interface for the module v1 service.
+type ModuleV1API interface {
+	// ModuleLatestForProvider returns the latest version of a module for a single provider.
+	// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+	ModuleLatestForProvider(req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error)
+}
+
+// ModuleLatestForProviderRequest is a request parameter for ModuleLatestForProvider().
+// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+type ModuleLatestForProviderRequest struct {
+	// Namespace is the user name which owns the module.
+	Namespace string `json:"namespace"`
+	// Name is the name of the module.
+	Name string `json:"name"`
+	// Provider is the name of the provider.
+	Provider string `json:"provider"`
+}
+
+// ModuleLatestForProviderResponse is a response data for ModuleLatestForProvider().
+// There are other response fields, but we define only those we need here.
+type ModuleLatestForProviderResponse struct {
+	// Version is the latest version of the module for a specific provider.
+	Version string `json:"version"`
+}
+
+// ModuleLatestForProvider returns the latest version of a module for a single provider.
+// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error) {
+	subPath := fmt.Sprintf("/%s/%s/%s/%s", moduleV1Service, req.Namespace, req.Name, req.Provider)
+
+	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResponse, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to HTTP Request: err = %s, req = %#v", err, httpRequest)
+	}
+
+	if httpResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected HTTP Status Code: %d, response: %#v", httpResponse.StatusCode, httpResponse)
+	}
+
+	var res ModuleLatestForProviderResponse
+	if err := decodeBody(httpResponse, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/tfregistry/module_test.go
+++ b/tfregistry/module_test.go
@@ -1,0 +1,61 @@
+package tfregistry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestModuleLatestForProvider(t *testing.T) {
+	cases := []struct {
+		desc string
+		req  *ModuleLatestForProviderRequest
+		ok   bool
+		res  string
+		want *ModuleLatestForProviderResponse
+	}{
+		{
+			desc: "simple",
+			req: &ModuleLatestForProviderRequest{
+				Namespace: "terraform-aws-modules",
+				Name:      "vpc",
+				Provider:  "aws",
+			},
+			ok: true,
+			res: `{
+				"version": "2.24.0"
+			}`,
+			want: &ModuleLatestForProviderResponse{
+				Version: "2.24.0",
+			},
+		},
+	}
+
+	mux, mockServerURL := newMockServer()
+	client := newTestClient(mockServerURL)
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			subPath := fmt.Sprintf("/%s/%s/%s/%s", moduleV1Service, tc.req.Namespace, tc.req.Name, tc.req.Provider)
+			mux.HandleFunc(subPath, func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, tc.res)
+			})
+
+			got, err := client.ModuleLatestForProvider(context.Background(), tc.req)
+
+			if tc.ok && err != nil {
+				t.Fatalf("failed to call ModuleLatestForProvider: err = %s, req = %#v", err, tc.req)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to fail, but success: req = %#v", tc.req)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got=%#v, but want=%#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfregistry/module_test.go
+++ b/tfregistry/module_test.go
@@ -38,7 +38,7 @@ func TestModuleLatestForProvider(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			subPath := fmt.Sprintf("/%s/%s/%s/%s", moduleV1Service, tc.req.Namespace, tc.req.Name, tc.req.Provider)
+			subPath := fmt.Sprintf("%s%s/%s/%s", moduleV1Service, tc.req.Namespace, tc.req.Name, tc.req.Provider)
 			mux.HandleFunc(subPath, func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, tc.res)
 			})


### PR DESCRIPTION
Add `--source-type tfregistryModule` to the `release latest` command to allow us to get the latest version number of a given module from Terraform Registry.

```
$ tfupdate release latest --source-type tfregistryModule terraform-aws-modules/vpc/aws
2.24.0
```

To avoid depending on a specific version of Terraform, we implement a pure Terraform Registry API client.
https://www.terraform.io/docs/registry/api.html

Currently only the official public registry is supported. There are other APIs and request/response fields, but we define only the ones we need here to keep it simple. The service discovery protocol is also not implemented for now.