### PR TITLE
Add release list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Usage: tfupdate release <subcommand> [options] [args]
 
 Subcommands:
     latest    Get the latest release version
+    list      Get a list of release versions
 ```
 
 ```
@@ -239,6 +240,39 @@ $ tfupdate release latest terraform-providers/terraform-provider-aws
 If you want to access private repositories on GitHub, export your access token to the `GITHUB_TOKEN` environment variable.
 
 If you want to access public or private repositories on GitLab, export your access token with api permissions to the `GITLAB_TOKEN` environment variable. If you are using an instance that is not `https://gitlab.com`, set the correct base URL to the `GITLAB_BASE_URL` environment variable (defaults to `https://gitlab.com/api/v4/`).
+
+```
+$ tfupdate release list --help
+Usage: tfupdate release list [options] <SOURCE>
+
+Arguments
+  SOURCE             A path of release data source.
+                     Valid format depends on --source-type option.
+                       - github or gitlab:
+                         owner/repo
+                         e.g. terraform-providers/terraform-provider-aws
+                      - tfregistryModule
+                         namespace/name/provider
+                         e.g. terraform-aws-modules/vpc/aws
+
+Options:
+  -s  --source-type  A type of release data source.
+                     Valid values are
+                       - github (default)
+                       - gitlab
+                       - tfregistryModule
+
+  -n  --max-length   The maximum length of list.
+```
+
+```
+$ tfupdate release list -n 5 hashicorp/terraform
+0.12.17
+0.12.18
+0.12.19
+0.12.20
+0.12.21
+```
 
 ## Keep your dependencies up-to-date
 

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -1,0 +1,84 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+// ReleaseListCommand is a command which gets a list of release versions.
+type ReleaseListCommand struct {
+	Meta
+	maxLength  int
+	sourceType string
+	source     string
+}
+
+// Run runs the procedure of this command.
+func (c *ReleaseListCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("release list", flag.ContinueOnError)
+	cmdFlags.IntVarP(&c.maxLength, "max-length", "n", 10, "the maximum length of list")
+	cmdFlags.StringVarP(&c.sourceType, "source-type", "s", "github", "A type of release data source")
+
+	if err := cmdFlags.Parse(args); err != nil {
+		c.UI.Error(fmt.Sprintf("failed to parse arguments: %s", err))
+		return 1
+	}
+
+	if len(cmdFlags.Args()) != 1 {
+		c.UI.Error(fmt.Sprintf("The command expects 1 argument, but got %d", len(cmdFlags.Args())))
+		c.UI.Error(c.Help())
+		return 1
+	}
+
+	c.source = cmdFlags.Arg(0)
+
+	r, err := newRelease(c.sourceType, c.source)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	versions, err := r.List(context.Background(), c.maxLength)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Output(strings.Join(versions, "\n"))
+	return 0
+}
+
+// Help returns long-form help text.
+func (c *ReleaseListCommand) Help() string {
+	helpText := `
+Usage: tfupdate release list [options] <SOURCE>
+
+Arguments
+  SOURCE             A path of release data source.
+                     Valid format depends on --source-type option.
+                       - github or gitlab:
+                         owner/repo
+                         e.g. terraform-providers/terraform-provider-aws
+                      - tfregistryModule
+                         namespace/name/provider
+                         e.g. terraform-aws-modules/vpc/aws
+
+Options:
+  -s  --source-type  A type of release data source.
+                     Valid values are
+                       - github (default)
+                       - gitlab
+                       - tfregistryModule
+
+  -n  --max-length   The maximum length of list.
+`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis returns one-line help text.
+func (c *ReleaseListCommand) Synopsis() string {
+	return "Get a list of release versions"
+}

--- a/main.go
+++ b/main.go
@@ -103,6 +103,11 @@ func initCommands() map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"release list": func() (cli.Command, error) {
+			return &command.ReleaseListCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 
 	return commands

--- a/release/github.go
+++ b/release/github.go
@@ -165,7 +165,7 @@ func (r *GitHubRelease) List(ctx context.Context, maxLength int) ([]string, erro
 	end := minInt(maxLength, len(versions))
 	desc := versions[:end]
 	// return a list order by release asc (probably created_at)
-	// Note that this may be not in version number order.
+	// Note that this may not be in version number order.
 	// It's a simply reversed list of release.
 	return reverseStringSlice(desc), nil
 }

--- a/release/github.go
+++ b/release/github.go
@@ -167,12 +167,3 @@ func (r *GitHubRelease) List(ctx context.Context, maxLength int) ([]string, erro
 	}
 	return versions, nil
 }
-
-func tagNameToVersion(tagName string) string {
-	// if a tagName starts with `v`, remove it.
-	if tagName[0] == 'v' {
-		return tagName[1:]
-	}
-
-	return tagName
-}

--- a/release/github.go
+++ b/release/github.go
@@ -162,8 +162,10 @@ func (r *GitHubRelease) List(ctx context.Context, maxLength int) ([]string, erro
 		opt.Page = resp.NextPage
 	}
 
-	if maxLength < len(versions) {
-		return versions[:maxLength], nil
-	}
-	return versions, nil
+	end := minInt(maxLength, len(versions))
+	desc := versions[:end]
+	// return a list order by release asc (probably created_at)
+	// Note that this may be not in version number order.
+	// It's a simply reversed list of release.
+	return reverseStringSlice(desc), nil
 }

--- a/release/github_test.go
+++ b/release/github_test.go
@@ -253,7 +253,7 @@ func TestGitHubReleaseList(t *testing.T) {
 				err:      nil,
 			},
 			maxLength: 2,
-			want:      []string{"0.2.0", "0.3.0"},
+			want:      []string{"0.2.0", "0.3.0"}, // limit length
 			ok:        true,
 		},
 		{

--- a/release/github_test.go
+++ b/release/github_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -12,13 +13,18 @@ import (
 
 // mockGitHubClient is a mock GitHubAPI implementation.
 type mockGitHubClient struct {
-	repositoryRelease *github.RepositoryRelease
-	response          *github.Response
-	err               error
+	repositoryRelease  *github.RepositoryRelease
+	repositoryReleases []*github.RepositoryRelease
+	response           *github.Response
+	err                error
 }
 
 func (c *mockGitHubClient) RepositoriesGetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error) {
 	return c.repositoryRelease, c.response, c.err
+}
+
+func (c *mockGitHubClient) RepositoriesListReleases(ctx context.Context, owner, repo string, opt *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+	return c.repositoryReleases, c.response, c.err
 }
 
 func TestNewGitHubClient(t *testing.T) {
@@ -210,6 +216,83 @@ func TestGitHubReleaseLatest(t *testing.T) {
 
 		if got != tc.want {
 			t.Errorf("(*GitHubRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
+		}
+	}
+}
+
+func TestGitHubReleaseList(t *testing.T) {
+	tagv := []string{"v0.3.0", "v0.2.0", "v0.1.0"}
+	tag := []string{"0.3.0", "0.2.0", "0.1.0"}
+	cases := []struct {
+		client    *mockGitHubClient
+		maxLength int
+		want      []string
+		ok        bool
+	}{
+		{
+			client: &mockGitHubClient{
+				repositoryReleases: []*github.RepositoryRelease{
+					&github.RepositoryRelease{TagName: &tagv[0]},
+					&github.RepositoryRelease{TagName: &tagv[1]},
+					&github.RepositoryRelease{TagName: &tagv[2]},
+				},
+				response: &github.Response{},
+				err:      nil,
+			},
+			maxLength: 5,
+			want:      tag,
+			ok:        true,
+		},
+		{
+			client: &mockGitHubClient{
+				repositoryReleases: []*github.RepositoryRelease{
+					&github.RepositoryRelease{TagName: &tagv[0]},
+					&github.RepositoryRelease{TagName: &tagv[1]},
+					&github.RepositoryRelease{TagName: &tagv[2]},
+				},
+				response: &github.Response{},
+				err:      nil,
+			},
+			maxLength: 2,
+			want:      tag[:2],
+			ok:        true,
+		},
+		{
+			client: &mockGitHubClient{
+				repositoryReleases: nil,
+				response:           &github.Response{},
+				// Actual error response type is *github.ErrorResponse,
+				// but we are not interested in the internal structure.
+				err: errors.New(`GET https://api.github.com/repos/hoge/fuga/releases: 404 Not Found []`),
+			},
+			want: []string{},
+			ok:   false,
+		},
+	}
+
+	source := "hoge/fuga"
+	for _, tc := range cases {
+		// Set a mock client
+		config := GitHubConfig{
+			api: tc.client,
+		}
+		r, err := NewGitHubRelease(source, config)
+		if err != nil {
+			t.Fatalf("failed to NewGitHubRelease(%s, %#v): %s", source, config, err)
+		}
+
+		got, err := r.List(context.Background(), tc.maxLength)
+
+		if tc.ok && err != nil {
+			t.Errorf("(*GitHubRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("(*GitHubRelease).List() with r = %s, maxLength = %d expects to return an error, but no error", spew.Sdump(r), tc.maxLength)
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("(*GitHubRelease).List() with r = %s, maxLength = %d returns %s, but want = %s", spew.Sdump(r), tc.maxLength, got, tc.want)
 		}
 	}
 }

--- a/release/github_test.go
+++ b/release/github_test.go
@@ -222,7 +222,6 @@ func TestGitHubReleaseLatest(t *testing.T) {
 
 func TestGitHubReleaseList(t *testing.T) {
 	tagv := []string{"v0.3.0", "v0.2.0", "v0.1.0"}
-	tag := []string{"0.3.0", "0.2.0", "0.1.0"}
 	cases := []struct {
 		client    *mockGitHubClient
 		maxLength int
@@ -240,7 +239,7 @@ func TestGitHubReleaseList(t *testing.T) {
 				err:      nil,
 			},
 			maxLength: 5,
-			want:      tag,
+			want:      []string{"0.1.0", "0.2.0", "0.3.0"}, // reverse order
 			ok:        true,
 		},
 		{
@@ -254,7 +253,7 @@ func TestGitHubReleaseList(t *testing.T) {
 				err:      nil,
 			},
 			maxLength: 2,
-			want:      tag[:2],
+			want:      []string{"0.2.0", "0.3.0"},
 			ok:        true,
 		},
 		{

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -127,4 +128,9 @@ func (r *GitLabRelease) Latest(ctx context.Context) (string, error) {
 	}
 
 	return tagName, nil
+}
+
+// List returns a list of versions.
+func (r *GitLabRelease) List(ctx context.Context, maxLength int) ([]string, error) {
+	return nil, errors.New("not impplemented yet")
 }

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -153,8 +153,7 @@ func (r *GitLabRelease) List(ctx context.Context, maxLength int) ([]string, erro
 		opt.Page = resp.NextPage
 	}
 
-	if maxLength < len(versions) {
-		return versions[:maxLength], nil
-	}
-	return versions, nil
+	end := minInt(maxLength, len(versions))
+	desc := versions[:end]
+	return reverseStringSlice(desc), nil
 }

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -15,6 +14,9 @@ import (
 type GitLabAPI interface {
 	// ProjectGetLatestRelease fetches the latest published release for the project.
 	ProjectGetLatestRelease(ctx context.Context, owner, project string) (*gitlab.Release, *gitlab.Response, error)
+
+	// ProjectListReleases gets a pagenated of releases accessible by the authenticated user.
+	ProjectListReleases(ctx context.Context, owner, project string, opt *gitlab.ListReleasesOptions) ([]*gitlab.Release, *gitlab.Response, error)
 }
 
 // GitLabConfig is a set of configurations for GitLabRelease..
@@ -71,6 +73,11 @@ func (c *GitLabClient) ProjectGetLatestRelease(ctx context.Context, owner, proje
 	return latest, response, err
 }
 
+// ProjectListReleases gets a pagenated of releases accessible by the authenticated user.
+func (c *GitLabClient) ProjectListReleases(ctx context.Context, owner, project string, opt *gitlab.ListReleasesOptions) ([]*gitlab.Release, *gitlab.Response, error) {
+	return c.client.Releases.ListReleases(owner+"/"+project, opt, gitlab.WithContext(ctx))
+}
+
 // GitLabRelease is a release implementation which provides version information with GitLab Release.
 type GitLabRelease struct {
 	// api is an instance of GitLabAPI interface.
@@ -120,17 +127,34 @@ func (r *GitLabRelease) Latest(ctx context.Context) (string, error) {
 	}
 
 	// Use TagName because some releases do not have Name.
-	tagName := release.TagName
+	v := tagNameToVersion(release.TagName)
 
-	// if a tagName starts with `v`, remove it.
-	if tagName[0] == 'v' {
-		return tagName[1:], nil
-	}
-
-	return tagName, nil
+	return v, nil
 }
 
 // List returns a list of versions.
 func (r *GitLabRelease) List(ctx context.Context, maxLength int) ([]string, error) {
-	return nil, errors.New("not impplemented yet")
+	versions := []string{}
+	opt := &gitlab.ListReleasesOptions{}
+	for {
+		releases, resp, err := r.api.ProjectListReleases(ctx, r.owner, r.project, opt)
+
+		if err != nil {
+			return versions, fmt.Errorf("failed to list releases for %s/%s: %s", r.owner, r.project, err)
+		}
+
+		for _, release := range releases {
+			v := tagNameToVersion(release.TagName)
+			versions = append(versions, v)
+		}
+		if resp.NextPage == 0 || len(versions) >= maxLength {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	if maxLength < len(versions) {
+		return versions[:maxLength], nil
+	}
+	return versions, nil
 }

--- a/release/gitlab_test.go
+++ b/release/gitlab_test.go
@@ -231,7 +231,6 @@ func TestGitLabReleaseLatest(t *testing.T) {
 // Test of GitLabRelease.List(ctx context.Context, maxLength int)
 func TestGitLabReleaseList(t *testing.T) {
 	tagv := []string{"v0.3.0", "v0.2.0", "v0.1.0"}
-	tag := []string{"0.3.0", "0.2.0", "0.1.0"}
 	cases := []struct {
 		client    *mockGitLabClient
 		maxLength int
@@ -249,7 +248,7 @@ func TestGitLabReleaseList(t *testing.T) {
 				err:      nil,
 			},
 			maxLength: 5,
-			want:      tag,
+			want:      []string{"0.1.0", "0.2.0", "0.3.0"}, // reverse order
 			ok:        true,
 		},
 		// test len(versions) > maxLength
@@ -264,7 +263,7 @@ func TestGitLabReleaseList(t *testing.T) {
 				err:      nil,
 			},
 			maxLength: 2,
-			want:      tag[:2],
+			want:      []string{"0.2.0", "0.3.0"},
 			ok:        true,
 		},
 		// test unreachable/invalid project

--- a/release/release.go
+++ b/release/release.go
@@ -8,4 +8,6 @@ import (
 type Release interface {
 	// Latest returns a latest version.
 	Latest(ctx context.Context) (string, error)
+	// List returns a list of versions.
+	List(ctx context.Context, maxLength int) ([]string, error)
 }

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -125,6 +125,8 @@ func (r *TFRegistryModuleRelease) List(ctx context.Context, maxLength int) ([]st
 		Name:      r.name,
 		Provider:  r.provider,
 	}
+	// Hard to guess from the name, the response of ModuleLatestForProvider API contains
+	// not only the latest version, but also a list of available versions.
 	release, err := r.api.ModuleLatestForProvider(ctx, req)
 
 	if err != nil {
@@ -132,6 +134,7 @@ func (r *TFRegistryModuleRelease) List(ctx context.Context, maxLength int) ([]st
 	}
 
 	versions := release.Versions
+	// versions are already in asc order unlike github.
 	start := len(versions) - minInt(maxLength, len(versions))
 	asc := versions[start:]
 	return asc, nil

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -131,8 +131,8 @@ func (r *TFRegistryModuleRelease) List(ctx context.Context, maxLength int) ([]st
 		return []string{}, fmt.Errorf("failed to get a list of versions for %s/%s/%s: %s", r.namespace, r.name, r.provider, err)
 	}
 
-	if maxLength < len(release.Versions) {
-		return release.Versions[len(release.Versions)-maxLength:], nil
-	}
-	return release.Versions, nil
+	versions := release.Versions
+	start := len(versions) - minInt(maxLength, len(versions))
+	asc := versions[start:]
+	return asc, nil
 }

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -116,4 +117,9 @@ func (r *TFRegistryModuleRelease) Latest(ctx context.Context) (string, error) {
 	}
 
 	return release.Version, nil
+}
+
+// List returns a list of versions.
+func (r *TFRegistryModuleRelease) List(ctx context.Context, maxLength int) ([]string, error) {
+	return nil, errors.New("not impplemented yet")
 }

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -121,5 +120,19 @@ func (r *TFRegistryModuleRelease) Latest(ctx context.Context) (string, error) {
 
 // List returns a list of versions.
 func (r *TFRegistryModuleRelease) List(ctx context.Context, maxLength int) ([]string, error) {
-	return nil, errors.New("not impplemented yet")
+	req := &tfregistry.ModuleLatestForProviderRequest{
+		Namespace: r.namespace,
+		Name:      r.name,
+		Provider:  r.provider,
+	}
+	release, err := r.api.ModuleLatestForProvider(ctx, req)
+
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get a list of versions for %s/%s/%s: %s", r.namespace, r.name, r.provider, err)
+	}
+
+	if maxLength < len(release.Versions) {
+		return release.Versions[len(release.Versions)-maxLength:], nil
+	}
+	return release.Versions, nil
 }

--- a/release/version.go
+++ b/release/version.go
@@ -1,0 +1,10 @@
+package release
+
+func tagNameToVersion(tagName string) string {
+	// if a tagName starts with `v`, remove it.
+	if tagName[0] == 'v' {
+		return tagName[1:]
+	}
+
+	return tagName
+}

--- a/release/version.go
+++ b/release/version.go
@@ -8,3 +8,19 @@ func tagNameToVersion(tagName string) string {
 
 	return tagName
 }
+
+func reverseStringSlice(s []string) []string {
+	r := []string{}
+	// apparently inefficient but simple way
+	for i := len(s) - 1; i >= 0; i-- {
+		r = append(r, s[i])
+	}
+	return r
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -20,7 +20,11 @@ const (
 type ModuleV1API interface {
 	// ModuleLatestForProvider returns the latest version of a module for a single provider.
 	// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
-	ModuleLatestForProvider(req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error)
+	ModuleLatestForProvider(ctx context.Context, req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error)
+
+	// ModuleListVersionsForProvider is the primary endpoint for resolving module sources, returning the available versions for a given fully-qualified module.
+	// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
+	ModuleListVersionsForProvider(ctx context.Context, req *ModuleListVersionsForProviderRequest) (*ModuleListVersionsForProviderResponse, error)
 }
 
 // ModuleLatestForProviderRequest is a request parameter for ModuleLatestForProvider().
@@ -71,6 +75,75 @@ func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestF
 	}
 
 	var res ModuleLatestForProviderResponse
+	if err := decodeBody(httpResponse, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// ModuleListVersionsForProviderRequest is a request parameter for ModuleListVersionsForProvider().
+// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
+type ModuleListVersionsForProviderRequest struct {
+	// Namespace is a user name which owns the module.
+	Namespace string `json:"namespace"`
+	// Name is a name of the module.
+	Name string `json:"name"`
+	// Provider is a name of the provider.
+	Provider string `json:"provider"`
+}
+
+// ModuleListVersionsForProviderResponse is a response data for ModuleListVersionsForProvider().
+// There are other response fields, but we define only those we need here.
+type ModuleListVersionsForProviderResponse struct {
+	// Version is the latest version of the module for a specific provider.
+	Modules []*ModuleProviderVersions `json:"modules"`
+}
+
+// ModuleProviderVersions is a set of meta data for a module.
+type ModuleProviderVersions struct {
+	// Versions is a list of available versions of the module for a specific provider.
+	Versions []*ModuleVersion `json:"versions"`
+}
+
+// ModuleVersion is a set of meta data of a single version.
+type ModuleVersion struct {
+	// Source is a
+	Source string `json:"source"`
+	// Version is a version of the module for a specific provider.
+	Version string `json:"version"`
+}
+
+// ModuleListVersionsForProvider is the primary endpoint for resolving module sources, returning the available versions for a given fully-qualified module.
+// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
+func (c *Client) ModuleListVersionsForProvider(ctx context.Context, req *ModuleListVersionsForProviderRequest) (*ModuleListVersionsForProviderResponse, error) {
+	if len(req.Namespace) == 0 {
+		return nil, fmt.Errorf("Invalid request. Namespace is required. req = %#v", req)
+	}
+	if len(req.Name) == 0 {
+		return nil, fmt.Errorf("Invalid request. Name is required. req = %#v", req)
+	}
+	if len(req.Provider) == 0 {
+		return nil, fmt.Errorf("Invalid request. Provider is required. req = %#v", req)
+	}
+
+	subPath := fmt.Sprintf("%s%s/%s/%s/versions", moduleV1Service, req.Namespace, req.Name, req.Provider)
+
+	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResponse, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to HTTP Request: err = %s, req = %#v", err, httpRequest)
+	}
+
+	if httpResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected HTTP Status Code: %d", httpResponse.StatusCode)
+	}
+
+	var res ModuleListVersionsForProviderResponse
 	if err := decodeBody(httpResponse, &res); err != nil {
 		return nil, err
 	}

--- a/tfregistry/module.go
+++ b/tfregistry/module.go
@@ -21,10 +21,6 @@ type ModuleV1API interface {
 	// ModuleLatestForProvider returns the latest version of a module for a single provider.
 	// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
 	ModuleLatestForProvider(ctx context.Context, req *ModuleLatestForProviderRequest) (*ModuleLatestForProviderResponse, error)
-
-	// ModuleListVersionsForProvider is the primary endpoint for resolving module sources, returning the available versions for a given fully-qualified module.
-	// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
-	ModuleListVersionsForProvider(ctx context.Context, req *ModuleListVersionsForProviderRequest) (*ModuleListVersionsForProviderResponse, error)
 }
 
 // ModuleLatestForProviderRequest is a request parameter for ModuleLatestForProvider().
@@ -43,6 +39,8 @@ type ModuleLatestForProviderRequest struct {
 type ModuleLatestForProviderResponse struct {
 	// Version is the latest version of the module for a specific provider.
 	Version string `json:"version"`
+	// Versions is a list of available versions.
+	Versions []string `json:"versions"`
 }
 
 // ModuleLatestForProvider returns the latest version of a module for a single provider.
@@ -75,75 +73,6 @@ func (c *Client) ModuleLatestForProvider(ctx context.Context, req *ModuleLatestF
 	}
 
 	var res ModuleLatestForProviderResponse
-	if err := decodeBody(httpResponse, &res); err != nil {
-		return nil, err
-	}
-
-	return &res, nil
-}
-
-// ModuleListVersionsForProviderRequest is a request parameter for ModuleListVersionsForProvider().
-// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
-type ModuleListVersionsForProviderRequest struct {
-	// Namespace is a user name which owns the module.
-	Namespace string `json:"namespace"`
-	// Name is a name of the module.
-	Name string `json:"name"`
-	// Provider is a name of the provider.
-	Provider string `json:"provider"`
-}
-
-// ModuleListVersionsForProviderResponse is a response data for ModuleListVersionsForProvider().
-// There are other response fields, but we define only those we need here.
-type ModuleListVersionsForProviderResponse struct {
-	// Version is the latest version of the module for a specific provider.
-	Modules []*ModuleProviderVersions `json:"modules"`
-}
-
-// ModuleProviderVersions is a set of meta data for a module.
-type ModuleProviderVersions struct {
-	// Versions is a list of available versions of the module for a specific provider.
-	Versions []*ModuleVersion `json:"versions"`
-}
-
-// ModuleVersion is a set of meta data of a single version.
-type ModuleVersion struct {
-	// Source is a
-	Source string `json:"source"`
-	// Version is a version of the module for a specific provider.
-	Version string `json:"version"`
-}
-
-// ModuleListVersionsForProvider is the primary endpoint for resolving module sources, returning the available versions for a given fully-qualified module.
-// https://www.terraform.io/docs/registry/api.html#list-available-versions-for-a-specific-module
-func (c *Client) ModuleListVersionsForProvider(ctx context.Context, req *ModuleListVersionsForProviderRequest) (*ModuleListVersionsForProviderResponse, error) {
-	if len(req.Namespace) == 0 {
-		return nil, fmt.Errorf("Invalid request. Namespace is required. req = %#v", req)
-	}
-	if len(req.Name) == 0 {
-		return nil, fmt.Errorf("Invalid request. Name is required. req = %#v", req)
-	}
-	if len(req.Provider) == 0 {
-		return nil, fmt.Errorf("Invalid request. Provider is required. req = %#v", req)
-	}
-
-	subPath := fmt.Sprintf("%s%s/%s/%s/versions", moduleV1Service, req.Namespace, req.Name, req.Provider)
-
-	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	httpResponse, err := c.httpClient.Do(httpRequest)
-	if err != nil {
-		return nil, fmt.Errorf("failed to HTTP Request: err = %s, req = %#v", err, httpRequest)
-	}
-
-	if httpResponse.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected HTTP Status Code: %d", httpResponse.StatusCode)
-	}
-
-	var res ModuleListVersionsForProviderResponse
 	if err := decodeBody(httpResponse, &res); err != nil {
 		return nil, err
 	}

--- a/tfregistry/module_test.go
+++ b/tfregistry/module_test.go
@@ -26,9 +26,10 @@ func TestModuleLatestForProvider(t *testing.T) {
 			},
 			ok:   true,
 			code: 200,
-			res:  `{"version": "2.24.0"}`,
+			res:  `{"version": "2.24.0", "versions": ["2.22.0", "2.23.0", "2.24.0"]}`,
 			want: &ModuleLatestForProviderResponse{
-				Version: "2.24.0",
+				Version:  "2.24.0",
+				Versions: []string{"2.22.0", "2.23.0", "2.24.0"},
 			},
 		},
 		{


### PR DESCRIPTION
Add `release list` command to get a list of available versions.

This is currently useful only for debug, but may also be useful in the future to support semantic version aware updates.

```
$ go run main.go release list -n 5 hashicorp/terraform
0.12.17
0.12.18
0.12.19
0.12.20
0.12.21
```