### PR TITLE
Support a new provider source syntax in Terraform v0.13

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,6 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.3.1-0.20200103191330-7990d6e9a2c9 h1:F7Masi+wpDftmxrpsVwm1m0z1YQNj1GjRLPln3SKEOc=
-github.com/hashicorp/hcl/v2 v2.3.1-0.20200103191330-7990d6e9a2c9/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/tfupdate/hclwrite.go
+++ b/tfupdate/hclwrite.go
@@ -45,13 +45,13 @@ func allMatchingBlocksByType(b *hclwrite.Body, typeName string) []*hclwrite.Bloc
 	return matched
 }
 
-// attributeToValue extracts cty.Value from hclwrite.Attribute.
+// getAttributeValue extracts cty.Value from hclwrite.Attribute.
 // At the time of writing, there is no way to do with the hclwrite AST,
 // so we build low-level byte sequences and parse an expression as a
 // hclsyntax.Expression on memory.
-func attributeToValue(a *hclwrite.Attribute) (cty.Value, error) {
+func getAttributeValue(attr *hclwrite.Attribute) (cty.Value, error) {
 	// build low-level byte sequences
-	src := a.Expr().BuildTokens(nil).Bytes()
+	src := attr.Expr().BuildTokens(nil).Bytes()
 
 	// parse an expression as a hclsyntax.Expression
 	expr, diags := hclsyntax.ParseExpression(src, "generated_by_attributeToValue", hcl.Pos{Line: 1, Column: 1})

--- a/tfupdate/hclwrite.go
+++ b/tfupdate/hclwrite.go
@@ -1,9 +1,13 @@
 package tfupdate
 
 import (
+	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // allMatchingBlocks returns all matching blocks from the body that have the
@@ -39,4 +43,29 @@ func allMatchingBlocksByType(b *hclwrite.Body, typeName string) []*hclwrite.Bloc
 	}
 
 	return matched
+}
+
+// attributeToValue extracts cty.Value from hclwrite.Attribute.
+// At the time of writing, there is no way to do with the hclwrite AST,
+// so we build low-level byte sequences and parse an expression as a
+// hclsyntax.Expression on memory.
+func attributeToValue(a *hclwrite.Attribute) (cty.Value, error) {
+	// build low-level byte sequences
+	src := a.Expr().BuildTokens(nil).Bytes()
+
+	// parse an expression as a hclsyntax.Expression
+	expr, diags := hclsyntax.ParseExpression(src, "generated_by_attributeToValue", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return cty.NilVal, fmt.Errorf("failed to parse expression: %s", diags)
+	}
+
+	// Get value from expression.
+	// We don't need interpolation for any variables and functions here,
+	// so we just pass an empty context.
+	v, diags := expr.Value(&hcl.EvalContext{})
+	if diags.HasErrors() {
+		return cty.NilVal, fmt.Errorf("failed to get cty.Value: %s", diags)
+	}
+
+	return v, nil
 }

--- a/tfupdate/provider.go
+++ b/tfupdate/provider.go
@@ -52,7 +52,7 @@ func (u *ProviderUpdater) updateTerraformBlock(f *hclwrite.File) error {
 
 		attr := p.Body().GetAttribute(u.name)
 		if attr != nil {
-			value, err := attributeToValue(attr)
+			value, err := getAttributeValue(attr)
 			if err != nil {
 				return err
 			}

--- a/tfupdate/provider_test.go
+++ b/tfupdate/provider_test.go
@@ -185,6 +185,89 @@ provider "aws" {
 `,
 			ok: true,
 		},
+		{
+			src: `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.65.0"
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.66.0"
+    }
+  }
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "2.1.2"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.65.0"
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "2.1.2"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.66.0"
+    }
+  }
+}
+`,
+			ok: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/tfupdate/provider_test.go
+++ b/tfupdate/provider_test.go
@@ -268,6 +268,56 @@ terraform {
 `,
 			ok: true,
 		},
+		{
+			src: `
+terraform {
+  required_providers {
+    # foo
+    aws = "2.65.0" # bar
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    # foo
+    aws = "2.66.0" # bar
+  }
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+terraform {
+  required_providers {
+    # foo
+    aws = {
+      # version = "2.65.0" # bar
+      version = "2.65.0" # baz
+      source  = "hashicorp/aws"
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    # foo
+    aws = {
+      # version = "2.65.0" # bar
+      version = "2.66.0" # baz
+      source  = "hashicorp/aws"
+    }
+  }
+}
+`,
+			ok: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #14 

Terraform v0.13 will introduce a provider source to support downloading community providers from Terraform Registry.
https://www.hashicorp.com/blog/adding-provider-source-to-hashicorp-terraform/

It extends a required_providers block and now we can set provider's source and version as an object type. So we check a type of value and switch implementations.
(Strictly speaking, a new required_providers object syntax was introduced in 0.12.20.)

Implementation Notes:
Updating the whole object loses original sort order and comments.
At the time of writing, there is no way to update a value inside an object directly while preserving original tokens.
Since we fully understand the valid syntax, we compromise and read the tokens in order, updating the bytes directly.
It's apparently a fragile dirty hack, but I didn't come up with the better way to do this.
