### PR TITLE
Use static link on build for alpine compatible

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
       - windows
     goarch:
       - amd64
+    env:
+      - CGO_ENABLED=0
 release:
   prerelease: auto
 changelog:


### PR DESCRIPTION
Fixes #22

The alpine doesn't have glibc, so we need to build with static link.

```
/ # ldd ./tfupdate
        /lib64/ld-linux-x86-64.so.2 (0x7fc31993c000)
        libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7fc31993c000)
        libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7fc31993c000)
```