### PR TITLE
Ignore case for log level passed in TFUPDATE_LOG environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .envrc
+.vscode
 bin/
 tmp/
 dist/

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/logutils"
 	"github.com/minamijoyo/tfupdate/command"
@@ -64,7 +65,7 @@ func logOutput() io.Writer {
 
 	filter := &logutils.LevelFilter{
 		Levels:   levels,
-		MinLevel: logutils.LogLevel(minLevel),
+		MinLevel: logutils.LogLevel(strings.ToUpper(minLevel)),
 		Writer:   writer,
 	}
 


### PR DESCRIPTION
Just like terraform does it: https://github.com/hashicorp/terraform/blob/97d64581c613dd899f59d6753e92033e7cf09b40/helper/logging/logging.go#L83