### PR TITLE
Support getting release versions of a provider from the terraform registry

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -42,6 +42,9 @@ func newRelease(sourceType string, source string) (release.Release, error) {
 	case "tfregistryModule":
 		config := release.TFRegistryConfig{}
 		return release.NewTFRegistryModuleRelease(source, config)
+	case "tfregistryProvider":
+		config := release.TFRegistryConfig{}
+		return release.NewTFRegistryProviderRelease(source, config)
 	default:
 		return nil, fmt.Errorf("failed to new release data source. unknown type: %s", sourceType)
 	}

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -63,6 +63,9 @@ Arguments
                       - tfregistryModule
                          namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                      - tfregistryProvider
+                         namespace/type
+                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -70,6 +73,7 @@ Options:
                        - github (default)
                        - gitlab
                        - tfregistryModule
+                       - tfregistryProvider
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -65,6 +65,9 @@ Arguments
                       - tfregistryModule
                          namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                      - tfregistryProvider
+                         namespace/type
+                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -72,6 +75,7 @@ Options:
                        - github (default)
                        - gitlab
                        - tfregistryModule
+                       - tfregistryProvider
 
   -n  --max-length   The maximum length of list.
 `

--- a/release/release.go
+++ b/release/release.go
@@ -4,10 +4,10 @@ import (
 	"context"
 )
 
-// Release is an interface which provides version information.
+// Release is an interface which provides version information of a module or provider.
 type Release interface {
-	// Latest returns a latest version.
+	// Latest returns the latest version of a module or provider.
 	Latest(ctx context.Context) (string, error)
-	// List returns a list of versions.
+	// List returns a list of versions of a module or provider.
 	List(ctx context.Context, maxLength int) ([]string, error)
 }

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -12,12 +12,17 @@ import (
 
 // mockTFRegistryClient is a mock TFRegistryAPI implementation.
 type mockTFRegistryClient struct {
-	moduleRes *tfregistry.ModuleLatestForProviderResponse
-	err       error
+	moduleRes   *tfregistry.ModuleLatestForProviderResponse
+	providerRes *tfregistry.ProviderLatestResponse
+	err         error
 }
 
 func (c *mockTFRegistryClient) ModuleLatestForProvider(ctx context.Context, req *tfregistry.ModuleLatestForProviderRequest) (*tfregistry.ModuleLatestForProviderResponse, error) {
 	return c.moduleRes, c.err
+}
+
+func (c *mockTFRegistryClient) ProviderLatest(ctx context.Context, req *tfregistry.ProviderLatestRequest) (*tfregistry.ProviderLatestResponse, error) {
+	return c.providerRes, c.err
 }
 
 func TestNewTFRegistryClient(t *testing.T) {
@@ -125,6 +130,57 @@ func TestNewTFRegistryModuleRelease(t *testing.T) {
 	}
 }
 
+func TestNewTFRegistryProviderRelease(t *testing.T) {
+	cases := []struct {
+		source       string
+		api          TFRegistryAPI
+		namespace    string
+		providerType string
+		ok           bool
+	}{
+		{
+			source:       "hoge/piyo",
+			api:          &mockTFRegistryClient{},
+			namespace:    "hoge",
+			providerType: "piyo",
+			ok:           true,
+		},
+		{
+			source:       "hoge",
+			api:          &mockTFRegistryClient{},
+			namespace:    "",
+			providerType: "",
+			ok:           false,
+		},
+	}
+
+	for _, tc := range cases {
+		config := TFRegistryConfig{
+			api: tc.api,
+		}
+		got, err := NewTFRegistryProviderRelease(tc.source, config)
+
+		if tc.ok && err != nil {
+			t.Errorf("NewTFRegistryProviderRelease() with source = %s, api = %#v returns unexpected err: %s", tc.source, tc.api, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("NewTFRegistryProviderRelease() with source = %s, api = %#v expects to return an error, but no error", tc.source, tc.api)
+		}
+
+		if tc.ok {
+			r := got.(*TFRegistryProviderRelease)
+
+			if r.api != tc.api {
+				t.Errorf("NewTFRegistryProviderRelease() with source = %s, api = %#v sets api = %#v, but want %s", tc.source, tc.api, r.api, tc.api)
+			}
+
+			if !(r.namespace == tc.namespace && r.providerType == tc.providerType) {
+				t.Errorf("NewTFRegistryProviderRelease() with source = %s, api = %#v returns (%s, %s), but want (%s, %s)", tc.source, tc.api, r.namespace, r.providerType, tc.namespace, tc.providerType)
+			}
+		}
+	}
+}
 func TestTFRegistryModuleReleaseLatest(t *testing.T) {
 	cases := []struct {
 		client *mockTFRegistryClient
@@ -178,6 +234,58 @@ func TestTFRegistryModuleReleaseLatest(t *testing.T) {
 	}
 }
 
+func TestTFRegistryProviderReleaseLatest(t *testing.T) {
+	cases := []struct {
+		client *mockTFRegistryClient
+		want   string
+		ok     bool
+	}{
+		{
+			client: &mockTFRegistryClient{
+				providerRes: &tfregistry.ProviderLatestResponse{
+					Version: "0.1.0",
+				},
+				err: nil,
+			},
+			want: "0.1.0",
+			ok:   true,
+		},
+		{
+			client: &mockTFRegistryClient{
+				providerRes: nil,
+				err:         errors.New(`unexpected HTTP Status Code: 404`),
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	source := "hoge/piyo"
+	for _, tc := range cases {
+		// Set a mock client
+		config := TFRegistryConfig{
+			api: tc.client,
+		}
+		r, err := NewTFRegistryProviderRelease(source, config)
+		if err != nil {
+			t.Fatalf("failed to NewTFRegistryProviderRelease(%s, %#v): %s", source, config, err)
+		}
+
+		got, err := r.Latest(context.Background())
+
+		if tc.ok && err != nil {
+			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
+		}
+
+		if got != tc.want {
+			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
+		}
+	}
+}
 func TestTFRegistryModuleReleaseList(t *testing.T) {
 	cases := []struct {
 		client    *mockTFRegistryClient
@@ -242,6 +350,74 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 
 		if !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("(*TFRegistryModuleRelease).List() with r = %s, maxLength = %d returns %s, but want = %s", spew.Sdump(r), tc.maxLength, got, tc.want)
+		}
+	}
+}
+
+func TestTFRegistryProviderReleaseList(t *testing.T) {
+	cases := []struct {
+		client    *mockTFRegistryClient
+		maxLength int
+		want      []string
+		ok        bool
+	}{
+		{
+			client: &mockTFRegistryClient{
+				providerRes: &tfregistry.ProviderLatestResponse{
+					Version:  "0.3.0",
+					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
+				},
+				err: nil,
+			},
+			maxLength: 5,
+			want:      []string{"0.1.0", "0.2.0", "0.3.0"},
+			ok:        true,
+		},
+		{
+			client: &mockTFRegistryClient{
+				providerRes: &tfregistry.ProviderLatestResponse{
+					Version:  "0.3.0",
+					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
+				},
+				err: nil,
+			},
+			maxLength: 2,
+			want:      []string{"0.2.0", "0.3.0"},
+			ok:        true,
+		},
+		{
+			client: &mockTFRegistryClient{
+				providerRes: nil,
+				err:         errors.New(`unexpected HTTP Status Code: 404`),
+			},
+			want: []string{},
+			ok:   false,
+		},
+	}
+
+	source := "hoge/piyo"
+	for _, tc := range cases {
+		// Set a mock client
+		config := TFRegistryConfig{
+			api: tc.client,
+		}
+		r, err := NewTFRegistryProviderRelease(source, config)
+		if err != nil {
+			t.Fatalf("failed to NewTFRegistryProviderRelease(%s, %#v): %s", source, config, err)
+		}
+
+		got, err := r.List(context.Background(), tc.maxLength)
+
+		if tc.ok && err != nil {
+			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)
+		}
+
+		if !tc.ok && err == nil {
+			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d expects to return an error, but no error", spew.Sdump(r), tc.maxLength)
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d returns %s, but want = %s", spew.Sdump(r), tc.maxLength, got, tc.want)
 		}
 	}
 }

--- a/tfregistry/provider.go
+++ b/tfregistry/provider.go
@@ -1,0 +1,79 @@
+package tfregistry
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// providerV1Service is a sub path of provider v1 service endpoint.
+	// The service discovery protocol is not implemented for now.
+	// https://www.terraform.io/docs/internals/provider-registry-protocol.html#service-discovery
+	//
+	// Include slashes for later implementation of service discovery.
+	// curl https://registry.terraform.io/.well-known/terraform.json
+	// {"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}
+	providerV1Service = "/v1/providers/"
+)
+
+// ProviderV1API is an interface for the provider v1 service.
+type ProviderV1API interface {
+	// ProviderLatest returns the latest version of a provider.
+	// This relies on a currently undocumented providers API endpoint which behaves exactly like the equivalent documented modules API endpoint.
+	// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+	ProviderLatest(ctx context.Context, req *ProviderLatestRequest) (*ProviderLatestResponse, error)
+}
+
+// ProviderLatestRequest is a request parameter for ProviderLatest().
+// This relies on a currently undocumented providers API endpoint which behaves exactly like the equivalent documented modules API endpoint.
+// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+type ProviderLatestRequest struct {
+	// Namespace is the name of a namespace, unique on a particular hostname, that can contain one or more providers that are somehow related. On the public Terraform Registry the "namespace" represents the organization that is packaging and distributing the provider.
+	Namespace string `json:"namespace"`
+	// Type is the provider type, like "azurerm", "aws", "google", "dns", etc. A provider type is unique within a particular hostname and namespace.
+	Type string `json:"type"`
+}
+
+// ProviderLatestResponse is a response data for ProviderLatest().
+// There are other response fields, but we define only those we need here.
+type ProviderLatestResponse struct {
+	// Version is the latest version of the provider.
+	Version string `json:"version"`
+	// Versions is a list of available versions.
+	Versions []string `json:"versions"`
+}
+
+// ProviderLatest returns the latest version of a provider.
+// This relies on a currently undocumented providers API endpoint which behaves exactly like the equivalent documented modules API endpoint.
+// https://www.terraform.io/docs/registry/api.html#latest-version-for-a-specific-module-provider
+func (c *Client) ProviderLatest(ctx context.Context, req *ProviderLatestRequest) (*ProviderLatestResponse, error) {
+	if len(req.Namespace) == 0 {
+		return nil, fmt.Errorf("Invalid request. Namespace is required. req = %#v", req)
+	}
+	if len(req.Type) == 0 {
+		return nil, fmt.Errorf("Invalid request. Type is required. req = %#v", req)
+	}
+
+	subPath := fmt.Sprintf("%s%s/%s", providerV1Service, req.Namespace, req.Type)
+
+	httpRequest, err := c.newRequest(ctx, "GET", subPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResponse, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to HTTP Request: err = %s, req = %#v", err, httpRequest)
+	}
+
+	if httpResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected HTTP Status Code: %d", httpResponse.StatusCode)
+	}
+
+	var res ProviderLatestResponse
+	if err := decodeBody(httpResponse, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/tfregistry/provider_test.go
+++ b/tfregistry/provider_test.go
@@ -1,0 +1,94 @@
+package tfregistry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestProviderLatest(t *testing.T) {
+	cases := []struct {
+		desc string
+		req  *ProviderLatestRequest
+		ok   bool
+		code int
+		res  string
+		want *ProviderLatestResponse
+	}{
+		{
+			desc: "simple",
+			req: &ProviderLatestRequest{
+				Namespace: "hashicorp",
+				Type:      "aws",
+			},
+			ok:   true,
+			code: 200,
+			res:  `{"version": "3.7.0", "versions": ["3.5.0", "3.6.0", "3.7.0"]}`,
+			want: &ProviderLatestResponse{
+				Version:  "3.7.0",
+				Versions: []string{"3.5.0", "3.6.0", "3.7.0"},
+			},
+		},
+		{
+			desc: "not found",
+			req: &ProviderLatestRequest{
+				Namespace: "hoge",
+				Type:      "piyo",
+			},
+			ok:   false,
+			code: 404,
+			res:  `{"errors":["Not Found"]}`,
+			want: nil,
+		},
+		{
+			desc: "invalid request (Namespace)",
+			req: &ProviderLatestRequest{
+				Namespace: "",
+				Type:      "piyo",
+			},
+			ok:   false,
+			code: 0,
+			res:  "",
+			want: nil,
+		},
+		{
+			desc: "invalid request (Type)",
+			req: &ProviderLatestRequest{
+				Namespace: "hoge",
+				Type:      "",
+			},
+			ok:   false,
+			code: 0,
+			res:  "",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mux, mockServerURL := newMockServer()
+			client := newTestClient(mockServerURL)
+			subPath := fmt.Sprintf("%s%s/%s", providerV1Service, tc.req.Namespace, tc.req.Type)
+			mux.HandleFunc(subPath, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.code)
+				fmt.Fprint(w, tc.res)
+			})
+
+			got, err := client.ProviderLatest(context.Background(), tc.req)
+
+			if tc.ok && err != nil {
+				t.Fatalf("failed to call ProviderLatest: err = %s, req = %#v", err, tc.req)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to fail, but success: req = %#v, got = %#v", tc.req, got)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got=%#v, but want=%#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for getting release versions of a provider from the terraform registry.

List versions:

```
# tfupdate release list -h
Usage: tfupdate release list [options] <SOURCE>

Arguments
  SOURCE             A path of release data source.
                     Valid format depends on --source-type option.
                       - github or gitlab:
                         owner/repo
                         e.g. terraform-providers/terraform-provider-aws
                      - tfregistryModule
                         namespace/name/provider
                         e.g. terraform-aws-modules/vpc/aws
                      - tfregistryProvider
                         namespace/type
                         e.g. hashicorp/aws

Options:
  -s  --source-type  A type of release data source.
                     Valid values are
                       - github (default)
                       - gitlab
                       - tfregistryModule
                       - tfregistryProvider

  -n  --max-length   The maximum length of list.

# tfupdate release list -s tfregistryProvider hashicorp/aws
2.69.0
2.70.0
3.0.0
3.1.0
3.2.0
3.3.0
3.4.0
3.5.0
3.6.0
3.7.0

# tfupdate release list -s tfregistryProvider datadog/datadog
2.12.1
2.13.0
```

Latest version:

```
# tfupdate release latest -h
Usage: tfupdate release latest [options] <SOURCE>

Arguments
  SOURCE             A path of release data source.
                     Valid format depends on --source-type option.
                       - github or gitlab:
                         owner/repo
                         e.g. terraform-providers/terraform-provider-aws
                      - tfregistryModule
                         namespace/name/provider
                         e.g. terraform-aws-modules/vpc/aws
                      - tfregistryProvider
                         namespace/type
                         e.g. hashicorp/aws

Options:
  -s  --source-type  A type of release data source.
                     Valid values are
                       - github (default)
                       - gitlab
                       - tfregistryModule
                       - tfregistryProvider

# tfupdate release latest -s tfregistryProvider hashicorp/aws
3.7.0

# tfupdate release latest -s tfregistryProvider datadog/datadog
2.13.0
```