### PR TITLE
Fix unexpected broken parentheses expression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-github/v28 v28.1.1
 	github.com/goreleaser/goreleaser v0.119.0
-	github.com/hashicorp/hcl/v2 v2.6.0
+	github.com/hashicorp/hcl/v2 v2.8.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/cli v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
-github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/hcl/v2 v2.8.0 h1:iHLEAsNDp3N2MtqroP1wf0nF/zB2+McHN5YCzwqIm80=
+github.com/hashicorp/hcl/v2 v2.8.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
Fixes #24

The upstream issue was fixed in hcl v2.8.0
https://github.com/hashicorp/hcl/issues/402

All we need is updating hcl to v2.8.0

```
[tfupdate@update-hcl-to-v2.8.0|✚2]$ cat tmp/test.tf
resource "google_container_cluster" "gke_cluster" {
  addons_config {
    network_policy_config {
      disabled = ! (length(var.gke_network_policy) > 0 && var.gke_network_policy[0].enabled)
    }
  }
}

[tfupdate@update-hcl-to-v2.8.0|✚2]$ go run main.go terraform tmp/test.tf

[tfupdate@update-hcl-to-v2.8.0|✚2]$ cat tmp/test.tf
resource "google_container_cluster" "gke_cluster" {
  addons_config {
    network_policy_config {
      disabled = ! (length(var.gke_network_policy) > 0 && var.gke_network_policy[0].enabled)
    }
  }
}
```