### PR TITLE
Update alpine to v3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tfupdate
-FROM golang:1.13.3-alpine3.10 AS tfupdate
+FROM golang:1.16.3-alpine3.12 AS tfupdate
 RUN apk --no-cache add make git
 WORKDIR /work
 
@@ -13,7 +13,7 @@ RUN make build
 # The linux binary for hub can not run on alpine.
 # So we need to build it from source.
 # https://github.com/github/hub/issues/1818
-FROM golang:1.13.3-alpine3.10 AS hub
+FROM golang:1.16.3-alpine3.12 AS hub
 RUN apk add --no-cache bash git
 RUN git clone https://github.com/github/hub /work
 WORKDIR /work
@@ -22,7 +22,7 @@ RUN ./script/build -o bin/hub
 # runtime
 # Note: Required Tools for Primary Containers on CircleCI
 # https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
-FROM alpine:3.10
+FROM alpine:3.12
 RUN apk --no-cache add bash git openssh-client tar gzip ca-certificates
 COPY --from=tfupdate /work/bin/tfupdate /usr/local/bin/
 COPY --from=hub /work/bin/hub /usr/local/bin/


### PR DESCRIPTION
The latest alpine is v3.13, but it has some DNS issues in old Docker Desktop. I'll use alpine v3.12 so that others can easily build the docker image.
https://github.com/alpinelinux/docker-alpine/issues/149

I also fixed go version I forgot to update in #37