### PR TITLE
Sort releases in semver order

### DIFF
--- a/command/provider.go
+++ b/command/provider.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/minamijoyo/tfupdate/release"
 	"github.com/minamijoyo/tfupdate/tfupdate"
 	flag "github.com/spf13/pflag"
 )
@@ -50,7 +51,7 @@ func (c *ProviderCommand) Run(args []string) int {
 			return 1
 		}
 
-		v, err = r.Latest(context.Background())
+		v, err = release.Latest(context.Background(), r)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 1

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/minamijoyo/tfupdate/release"
 	flag "github.com/spf13/pflag"
 )
 
@@ -39,7 +40,7 @@ func (c *ReleaseLatestCommand) Run(args []string) int {
 		return 1
 	}
 
-	v, err := r.Latest(context.Background())
+	v, err := release.Latest(context.Background(), r)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -41,7 +41,7 @@ func (c *ReleaseListCommand) Run(args []string) int {
 		return 1
 	}
 
-	versions, err := r.List(context.Background(), c.maxLength)
+	versions, err := r.List(context.Background(), c.maxLength, true)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/minamijoyo/tfupdate/release"
 	flag "github.com/spf13/pflag"
 )
 
@@ -41,7 +42,7 @@ func (c *ReleaseListCommand) Run(args []string) int {
 		return 1
 	}
 
-	versions, err := r.List(context.Background(), c.maxLength, true)
+	versions, err := release.List(context.Background(), r, c.maxLength, true)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/terraform.go
+++ b/command/terraform.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/minamijoyo/tfupdate/release"
 	"github.com/minamijoyo/tfupdate/tfupdate"
 	flag "github.com/spf13/pflag"
 )
@@ -47,7 +48,7 @@ func (c *TerraformCommand) Run(args []string) int {
 			return 1
 		}
 
-		v, err = r.Latest(context.Background())
+		v, err = release.Latest(context.Background(), r)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-github/v28 v28.1.1
 	github.com/goreleaser/goreleaser v0.119.0
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/release/release.go
+++ b/release/release.go
@@ -2,13 +2,49 @@ package release
 
 import (
 	"context"
+	"errors"
 )
 
 // Release is an interface which provides version information of a module or provider.
 type Release interface {
-	// Latest returns the latest version of a module or provider.
-	Latest(ctx context.Context) (string, error)
-	// List returns a list of versions of a module or provider in semver order.
-	// If preRelease is set to false, the result doesn't contain pre-releases.
-	List(ctx context.Context, maxLength int, preRelease bool) ([]string, error)
+	// ListReleases returns a list of unsorted all releases including pre-release.
+	ListReleases(ctx context.Context) ([]string, error)
+}
+
+// Latest returns the latest release.
+// Note that GetLatestRelease API in GitHub and GitLab returns the most recent
+// release, which doesn't means the latest stable release. I'm not sure it also
+// affects Terraform Registry but I think we should use the same strategy for
+// consistency. So we sort versions in semver order and find the latest non
+// pre-release.
+func Latest(ctx context.Context, r Release) (string, error) {
+	versions, err := List(ctx, r, 1, false)
+	if err != nil {
+		return "", err
+	}
+
+	if len(versions) == 0 {
+		return "", errors.New("no releases found")
+	}
+
+	return versions[0], nil
+}
+
+// List returns a list of releases in semver order.
+// If preRelease is set to false, the result doesn't contain pre-releases.
+func List(ctx context.Context, r Release, maxLength int, preRelease bool) ([]string, error) {
+	versions, err := r.ListReleases(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	sorted := sortVersions(versions)
+	releases := sorted
+
+	if !preRelease {
+		releases = excludePreReleases(sorted)
+	}
+
+	start := len(releases) - minInt(maxLength, len(releases))
+	return releases[start:], nil
 }

--- a/release/release.go
+++ b/release/release.go
@@ -8,6 +8,7 @@ import (
 type Release interface {
 	// Latest returns the latest version of a module or provider.
 	Latest(ctx context.Context) (string, error)
-	// List returns a list of versions of a module or provider.
-	List(ctx context.Context, maxLength int) ([]string, error)
+	// List returns a list of versions of a module or provider in semver order.
+	// If preRelease is set to false, the result doesn't contain pre-releases.
+	List(ctx context.Context, maxLength int, preRelease bool) ([]string, error)
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -1,0 +1,179 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type mockRelease struct {
+	versions []string
+	err      error
+}
+
+var _ Release = (*mockRelease)(nil)
+
+func (r *mockRelease) ListReleases(ctx context.Context) ([]string, error) {
+	return r.versions, r.err
+}
+
+func TestLatest(t *testing.T) {
+	cases := []struct {
+		desc string
+		r    Release
+		want string
+		ok   bool
+	}{
+		{
+			desc: "sort",
+			r: &mockRelease{
+				versions: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1"},
+				err:      nil,
+			},
+			want: "0.3.0",
+			ok:   true,
+		},
+		{
+			desc: "pre-release",
+			r: &mockRelease{
+				versions: []string{"0.1.0", "0.2.0", "0.1.1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-alpha1", "0.3.0-rc"},
+				err:      nil,
+			},
+			want: "0.2.0",
+			ok:   true,
+		},
+		{
+			desc: "no release",
+			r: &mockRelease{
+				versions: []string{},
+				err:      nil,
+			},
+			want: "",
+			ok:   false,
+		},
+		{
+			desc: "api error",
+			r: &mockRelease{
+				versions: nil,
+				err:      errors.New("mocked error"),
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := Latest(context.Background(), tc.r)
+
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %#v", err)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expects to return an error, but no error. got = %#v", got)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got = %#v, but want = %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	cases := []struct {
+		desc       string
+		r          Release
+		maxLength  int
+		preRelease bool
+		want       []string
+		ok         bool
+	}{
+		{
+			desc: "sort",
+			r: &mockRelease{
+				versions: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1"},
+				err:      nil,
+			},
+			maxLength:  5,
+			preRelease: true,
+			want:       []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0"},
+			ok:         true,
+		},
+		{
+			desc: "maxLength",
+			r: &mockRelease{
+				versions: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1"},
+				err:      nil,
+			},
+			maxLength:  3,
+			preRelease: true,
+			want:       []string{"0.1.1", "0.2.0", "0.3.0"},
+			ok:         true,
+		},
+		{
+			desc: "include pre-release",
+			r: &mockRelease{
+				versions: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-alpha1", "0.3.0-rc"},
+				err:      nil,
+			},
+			maxLength:  3,
+			preRelease: true,
+			want:       []string{"0.3.0-beta2", "0.3.0-rc", "0.3.0"},
+			ok:         true,
+		},
+		{
+			desc: "exclude pre-release",
+			r: &mockRelease{
+				versions: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-alpha1", "0.3.0-rc"},
+				err:      nil,
+			},
+			maxLength:  3,
+			preRelease: false,
+			want:       []string{"0.1.1", "0.2.0", "0.3.0"},
+			ok:         true,
+		},
+		{
+			desc: "empty",
+			r: &mockRelease{
+				versions: []string{},
+				err:      nil,
+			},
+			maxLength:  3,
+			preRelease: true,
+			want:       []string{},
+			ok:         true,
+		},
+		{
+			desc: "api error",
+			r: &mockRelease{
+				versions: nil,
+				err:      errors.New("mocked error"),
+			},
+			maxLength:  3,
+			preRelease: true,
+			want:       nil,
+			ok:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := List(context.Background(), tc.r, tc.maxLength, tc.preRelease)
+
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err: %#v", err)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expects to return an error, but no error. got = %#v", got)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got = %#v, but want = %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -17,6 +17,8 @@ type mockTFRegistryClient struct {
 	err         error
 }
 
+var _ TFRegistryAPI = (*mockTFRegistryClient)(nil)
+
 func (c *mockTFRegistryClient) ModuleLatestForProvider(ctx context.Context, req *tfregistry.ModuleLatestForProviderRequest) (*tfregistry.ModuleLatestForProviderResponse, error) {
 	return c.moduleRes, c.err
 }
@@ -181,144 +183,22 @@ func TestNewTFRegistryProviderRelease(t *testing.T) {
 		}
 	}
 }
-func TestTFRegistryModuleReleaseLatest(t *testing.T) {
+
+func TestTFRegistryModuleReleaseListReleases(t *testing.T) {
 	cases := []struct {
 		client *mockTFRegistryClient
-		want   string
+		want   []string
 		ok     bool
 	}{
 		{
 			client: &mockTFRegistryClient{
 				moduleRes: &tfregistry.ModuleLatestForProviderResponse{
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
+					Versions: []string{"0.3.0", "0.2.0", "0.1.0"},
 				},
 				err: nil,
 			},
-			want: "0.3.0",
+			want: []string{"0.3.0", "0.2.0", "0.1.0"},
 			ok:   true,
-		},
-		{
-			client: &mockTFRegistryClient{
-				moduleRes: nil,
-				err:       errors.New(`unexpected HTTP Status Code: 404`),
-			},
-			want: "",
-			ok:   false,
-		},
-	}
-
-	source := "hoge/fuga/piyo"
-	for _, tc := range cases {
-		// Set a mock client
-		config := TFRegistryConfig{
-			api: tc.client,
-		}
-		r, err := NewTFRegistryModuleRelease(source, config)
-		if err != nil {
-			t.Fatalf("failed to NewTFRegistryModuleRelease(%s, %#v): %s", source, config, err)
-		}
-
-		got, err := r.Latest(context.Background())
-
-		if tc.ok && err != nil {
-			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
-		}
-
-		if !tc.ok && err == nil {
-			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
-		}
-
-		if got != tc.want {
-			t.Errorf("(*TFRegistryModuleRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
-		}
-	}
-}
-
-func TestTFRegistryProviderReleaseLatest(t *testing.T) {
-	cases := []struct {
-		client *mockTFRegistryClient
-		want   string
-		ok     bool
-	}{
-		{
-			client: &mockTFRegistryClient{
-				providerRes: &tfregistry.ProviderLatestResponse{
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
-				},
-				err: nil,
-			},
-			want: "0.3.0",
-			ok:   true,
-		},
-		{
-			client: &mockTFRegistryClient{
-				providerRes: nil,
-				err:         errors.New(`unexpected HTTP Status Code: 404`),
-			},
-			want: "",
-			ok:   false,
-		},
-	}
-
-	source := "hoge/piyo"
-	for _, tc := range cases {
-		// Set a mock client
-		config := TFRegistryConfig{
-			api: tc.client,
-		}
-		r, err := NewTFRegistryProviderRelease(source, config)
-		if err != nil {
-			t.Fatalf("failed to NewTFRegistryProviderRelease(%s, %#v): %s", source, config, err)
-		}
-
-		got, err := r.Latest(context.Background())
-
-		if tc.ok && err != nil {
-			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
-		}
-
-		if !tc.ok && err == nil {
-			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s expects to return an error, but no error", spew.Sdump(r))
-		}
-
-		if got != tc.want {
-			t.Errorf("(*NewTFRegistryProviderRelease).Latest() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
-		}
-	}
-}
-func TestTFRegistryModuleReleaseList(t *testing.T) {
-	cases := []struct {
-		client     *mockTFRegistryClient
-		maxLength  int
-		preRelease bool
-		want       []string
-		ok         bool
-	}{
-		{
-			client: &mockTFRegistryClient{
-				moduleRes: &tfregistry.ModuleLatestForProviderResponse{
-					Version:  "0.3.0",
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
-				},
-				err: nil,
-			},
-			maxLength:  5,
-			preRelease: true,
-			want:       []string{"0.1.0", "0.2.0", "0.3.0"},
-			ok:         true,
-		},
-		{
-			client: &mockTFRegistryClient{
-				moduleRes: &tfregistry.ModuleLatestForProviderResponse{
-					Version:  "0.3.0",
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
-				},
-				err: nil,
-			},
-			maxLength:  2,
-			preRelease: true,
-			want:       []string{"0.2.0", "0.3.0"},
-			ok:         true,
 		},
 		{
 			client: &mockTFRegistryClient{
@@ -341,55 +221,37 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 			t.Fatalf("failed to NewTFRegistryModuleRelease(%s, %#v): %s", source, config, err)
 		}
 
-		got, err := r.List(context.Background(), tc.maxLength, tc.preRelease)
+		got, err := r.ListReleases(context.Background())
 
 		if tc.ok && err != nil {
-			t.Errorf("(*TFRegistryModuleRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)
+			t.Errorf("(*TFRegistryModuleRelease).ListReleases() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
 		}
 
 		if !tc.ok && err == nil {
-			t.Errorf("(*TFRegistryModuleRelease).List() with r = %s, maxLength = %d expects to return an error, but no error", spew.Sdump(r), tc.maxLength)
+			t.Errorf("(*TFRegistryModuleRelease).ListReleases() with r = %s expects to return an error, but no error", spew.Sdump(r))
 		}
 
 		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("(*TFRegistryModuleRelease).List() with r = %s, maxLength = %d returns %s, but want = %s", spew.Sdump(r), tc.maxLength, got, tc.want)
+			t.Errorf("(*TFRegistryModuleRelease).ListReleases() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
 		}
 	}
 }
 
-func TestTFRegistryProviderReleaseList(t *testing.T) {
+func TestTFRegistryProviderReleaseListReleases(t *testing.T) {
 	cases := []struct {
-		client     *mockTFRegistryClient
-		maxLength  int
-		preRelease bool
-		want       []string
-		ok         bool
+		client *mockTFRegistryClient
+		want   []string
+		ok     bool
 	}{
 		{
 			client: &mockTFRegistryClient{
 				providerRes: &tfregistry.ProviderLatestResponse{
-					Version:  "0.3.0",
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
+					Versions: []string{"0.3.0", "0.2.0", "0.1.0"},
 				},
 				err: nil,
 			},
-			maxLength:  5,
-			preRelease: true,
-			want:       []string{"0.1.0", "0.2.0", "0.3.0"},
-			ok:         true,
-		},
-		{
-			client: &mockTFRegistryClient{
-				providerRes: &tfregistry.ProviderLatestResponse{
-					Version:  "0.3.0",
-					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
-				},
-				err: nil,
-			},
-			maxLength:  2,
-			preRelease: true,
-			want:       []string{"0.2.0", "0.3.0"},
-			ok:         true,
+			want: []string{"0.3.0", "0.2.0", "0.1.0"},
+			ok:   true,
 		},
 		{
 			client: &mockTFRegistryClient{
@@ -412,18 +274,18 @@ func TestTFRegistryProviderReleaseList(t *testing.T) {
 			t.Fatalf("failed to NewTFRegistryProviderRelease(%s, %#v): %s", source, config, err)
 		}
 
-		got, err := r.List(context.Background(), tc.maxLength, tc.preRelease)
+		got, err := r.ListReleases(context.Background())
 
 		if tc.ok && err != nil {
-			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)
+			t.Errorf("(*NewTFRegistryProviderRelease).ListReleases() with r = %s returns unexpected err: %+v", spew.Sdump(r), err)
 		}
 
 		if !tc.ok && err == nil {
-			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d expects to return an error, but no error", spew.Sdump(r), tc.maxLength)
+			t.Errorf("(*NewTFRegistryProviderRelease).ListReleases() with r = %s expects to return an error, but no error", spew.Sdump(r))
 		}
 
 		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d returns %s, but want = %s", spew.Sdump(r), tc.maxLength, got, tc.want)
+			t.Errorf("(*NewTFRegistryProviderRelease).ListReleases() with r = %s returns %s, but want = %s", spew.Sdump(r), got, tc.want)
 		}
 	}
 }

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -190,11 +190,11 @@ func TestTFRegistryModuleReleaseLatest(t *testing.T) {
 		{
 			client: &mockTFRegistryClient{
 				moduleRes: &tfregistry.ModuleLatestForProviderResponse{
-					Version: "0.1.0",
+					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
 				},
 				err: nil,
 			},
-			want: "0.1.0",
+			want: "0.3.0",
 			ok:   true,
 		},
 		{
@@ -243,11 +243,11 @@ func TestTFRegistryProviderReleaseLatest(t *testing.T) {
 		{
 			client: &mockTFRegistryClient{
 				providerRes: &tfregistry.ProviderLatestResponse{
-					Version: "0.1.0",
+					Versions: []string{"0.1.0", "0.2.0", "0.3.0"},
 				},
 				err: nil,
 			},
-			want: "0.1.0",
+			want: "0.3.0",
 			ok:   true,
 		},
 		{
@@ -288,10 +288,11 @@ func TestTFRegistryProviderReleaseLatest(t *testing.T) {
 }
 func TestTFRegistryModuleReleaseList(t *testing.T) {
 	cases := []struct {
-		client    *mockTFRegistryClient
-		maxLength int
-		want      []string
-		ok        bool
+		client     *mockTFRegistryClient
+		maxLength  int
+		preRelease bool
+		want       []string
+		ok         bool
 	}{
 		{
 			client: &mockTFRegistryClient{
@@ -301,9 +302,10 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 				},
 				err: nil,
 			},
-			maxLength: 5,
-			want:      []string{"0.1.0", "0.2.0", "0.3.0"},
-			ok:        true,
+			maxLength:  5,
+			preRelease: true,
+			want:       []string{"0.1.0", "0.2.0", "0.3.0"},
+			ok:         true,
 		},
 		{
 			client: &mockTFRegistryClient{
@@ -313,16 +315,17 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 				},
 				err: nil,
 			},
-			maxLength: 2,
-			want:      []string{"0.2.0", "0.3.0"},
-			ok:        true,
+			maxLength:  2,
+			preRelease: true,
+			want:       []string{"0.2.0", "0.3.0"},
+			ok:         true,
 		},
 		{
 			client: &mockTFRegistryClient{
 				moduleRes: nil,
 				err:       errors.New(`unexpected HTTP Status Code: 404`),
 			},
-			want: []string{},
+			want: nil,
 			ok:   false,
 		},
 	}
@@ -338,7 +341,7 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 			t.Fatalf("failed to NewTFRegistryModuleRelease(%s, %#v): %s", source, config, err)
 		}
 
-		got, err := r.List(context.Background(), tc.maxLength)
+		got, err := r.List(context.Background(), tc.maxLength, tc.preRelease)
 
 		if tc.ok && err != nil {
 			t.Errorf("(*TFRegistryModuleRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)
@@ -356,10 +359,11 @@ func TestTFRegistryModuleReleaseList(t *testing.T) {
 
 func TestTFRegistryProviderReleaseList(t *testing.T) {
 	cases := []struct {
-		client    *mockTFRegistryClient
-		maxLength int
-		want      []string
-		ok        bool
+		client     *mockTFRegistryClient
+		maxLength  int
+		preRelease bool
+		want       []string
+		ok         bool
 	}{
 		{
 			client: &mockTFRegistryClient{
@@ -369,9 +373,10 @@ func TestTFRegistryProviderReleaseList(t *testing.T) {
 				},
 				err: nil,
 			},
-			maxLength: 5,
-			want:      []string{"0.1.0", "0.2.0", "0.3.0"},
-			ok:        true,
+			maxLength:  5,
+			preRelease: true,
+			want:       []string{"0.1.0", "0.2.0", "0.3.0"},
+			ok:         true,
 		},
 		{
 			client: &mockTFRegistryClient{
@@ -381,16 +386,17 @@ func TestTFRegistryProviderReleaseList(t *testing.T) {
 				},
 				err: nil,
 			},
-			maxLength: 2,
-			want:      []string{"0.2.0", "0.3.0"},
-			ok:        true,
+			maxLength:  2,
+			preRelease: true,
+			want:       []string{"0.2.0", "0.3.0"},
+			ok:         true,
 		},
 		{
 			client: &mockTFRegistryClient{
 				providerRes: nil,
 				err:         errors.New(`unexpected HTTP Status Code: 404`),
 			},
-			want: []string{},
+			want: nil,
 			ok:   false,
 		},
 	}
@@ -406,7 +412,7 @@ func TestTFRegistryProviderReleaseList(t *testing.T) {
 			t.Fatalf("failed to NewTFRegistryProviderRelease(%s, %#v): %s", source, config, err)
 		}
 
-		got, err := r.List(context.Background(), tc.maxLength)
+		got, err := r.List(context.Background(), tc.maxLength, tc.preRelease)
 
 		if tc.ok && err != nil {
 			t.Errorf("(*NewTFRegistryProviderRelease).List() with r = %s, maxLength = %d returns unexpected err: %+v", spew.Sdump(r), tc.maxLength, err)

--- a/release/version.go
+++ b/release/version.go
@@ -1,5 +1,11 @@
 package release
 
+import (
+	"sort"
+
+	version "github.com/hashicorp/go-version"
+)
+
 func tagNameToVersion(tagName string) string {
 	// if a tagName starts with `v`, remove it.
 	if tagName[0] == 'v' {
@@ -23,4 +29,49 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// toVersions converts []string to []*version.Version
+func toVersions(versionsRaw []string) []*version.Version {
+	versions := make([]*version.Version, len(versionsRaw))
+	for i, raw := range versionsRaw {
+		v, _ := version.NewVersion(raw)
+		versions[i] = v
+	}
+	return versions
+}
+
+// fromVersions converts []*version.Version to []string
+func fromVersions(versions []*version.Version) []string {
+	versionsRaw := make([]string, len(versions))
+	for i, v := range versions {
+		raw := v.String()
+		versionsRaw[i] = raw
+	}
+	return versionsRaw
+}
+
+// sortVersions sort a list of versions in semver order.
+func sortVersions(versionsRaw []string) []string {
+	versions := toVersions(versionsRaw)
+
+	// sort them in semver order
+	sort.Sort(version.Collection(versions))
+
+	return fromVersions(versions)
+}
+
+// excludePreReleases excludes pre-releases such as alpha, beta, rc.
+func excludePreReleases(versionsRaw []string) []string {
+	versions := toVersions(versionsRaw)
+
+	// exclude pre-release
+	filtered := []*version.Version{}
+	for _, v := range versions {
+		if len(v.Prerelease()) == 0 {
+			filtered = append(filtered, v)
+		}
+	}
+
+	return fromVersions(filtered)
 }

--- a/release/version_test.go
+++ b/release/version_test.go
@@ -1,0 +1,77 @@
+package release
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortVersions(t *testing.T) {
+	cases := []struct {
+		desc        string
+		versionsRaw []string
+		want        []string
+	}{
+		{
+			desc:        "simple",
+			versionsRaw: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1"},
+			want:        []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0"},
+		},
+		{
+			desc:        "empty",
+			versionsRaw: []string{},
+			want:        []string{},
+		},
+		{
+			desc:        "pre-release",
+			versionsRaw: []string{"0.3.0", "0.2.0", "0.1.0", "0.1.1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-alpha1", "0.3.0-rc"},
+			want:        []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0-alpha1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-rc", "0.3.0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := sortVersions(tc.versionsRaw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got = %#v, but want = %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExcludePreReleases(t *testing.T) {
+	cases := []struct {
+		desc        string
+		versionsRaw []string
+		want        []string
+	}{
+		{
+			desc:        "simple",
+			versionsRaw: []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0-alpha1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-rc", "0.3.0"},
+			want:        []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0"},
+		},
+		{
+			desc:        "no pre-relases",
+			versionsRaw: []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0"},
+			want:        []string{"0.1.0", "0.1.1", "0.2.0", "0.3.0"},
+		},
+		{
+			desc:        "no stable relases",
+			versionsRaw: []string{"0.3.0-alpha1", "0.3.0-beta1", "0.3.0-beta2", "0.3.0-rc"},
+			want:        []string{},
+		},
+		{
+			desc:        "empty",
+			versionsRaw: []string{},
+			want:        []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := excludePreReleases(tc.versionsRaw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got = %#v, but want = %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #36

Apparently I misunderstood the meaning of the latest release in GitHub. The latest release just means the most recent release, not the latest stable release. We should not use the GetLatestRelease API in GitHub. We need to get all releases, sort them in the semver order and find the latest stable release.

I also investigated and found that it also seems to be affect in GitLab. It also get releases order by released_at (default) or created_at, but not semver, and there is no API or UI to set the latest release.

I'm not sure it also affects Terraform Registry becasuse I don't have its account, but I think we should use the same strategy for consistency.