### PR TITLE
Hide pre-releases by default in the release list command

### DIFF
--- a/command/release_list.go
+++ b/command/release_list.go
@@ -13,6 +13,7 @@ import (
 type ReleaseListCommand struct {
 	Meta
 	maxLength  int
+	preRelease bool
 	sourceType string
 	source     string
 }
@@ -21,6 +22,7 @@ type ReleaseListCommand struct {
 func (c *ReleaseListCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("release list", flag.ContinueOnError)
 	cmdFlags.IntVarP(&c.maxLength, "max-length", "n", 10, "the maximum length of list")
+	cmdFlags.BoolVar(&c.preRelease, "pre-release", false, "show pre-releases")
 	cmdFlags.StringVarP(&c.sourceType, "source-type", "s", "github", "A type of release data source")
 
 	if err := cmdFlags.Parse(args); err != nil {
@@ -42,7 +44,7 @@ func (c *ReleaseListCommand) Run(args []string) int {
 		return 1
 	}
 
-	versions, err := release.List(context.Background(), r, c.maxLength, true)
+	versions, err := release.List(context.Background(), r, c.maxLength, c.preRelease)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1
@@ -79,6 +81,7 @@ Options:
                        - tfregistryProvider (experimental)
 
   -n  --max-length   The maximum length of list.
+      --pre-release  Show pre-releases. (default: false)
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
Fixes #31

The release list command now hides pre-releases by default and allows it to show by a new flag `--pre-release`.

```
[tfupdate@hide-preleases-by-default|✔]$ go run main.go release list hashicorp/terraform
0.14.6
0.14.7
0.14.8
0.14.9
0.14.10
0.14.11
0.15.0
0.15.1
0.15.2
0.15.3
```

```
[tfupdate@hide-preleases-by-default|✔]$ go run main.go release list --pre-release hashicorp/terraform
0.15.0-alpha20210127
0.15.0-alpha20210210
0.15.0-beta1
0.15.0-beta2
0.15.0-rc1
0.15.0-rc2
0.15.0
0.15.1
0.15.2
0.15.3
```

This was originally requested in #31, but there was an implementation concern for consistency at the time because all source types doesn't have the same API metadata. In #41, the list is now sorted in semver order and pre-releases can now be filtered in a consistent way for all source types. Since the list command is originally for debug, it is convenient to be able to switch the presence or absence of pre-releases.

There may be some opinions about whether the concept of release includes pre-release or not, but it's clear that latest must not be pre-release, and it seems convenient if the end of the list matches the latest for debug. So change it to hide pre-releases by default.

This is a breaking change, but it's a good opportunity to change the default in the next release because the order was changed by #41.