### PR TITLE
Allow to parse the configuration_aliases syntax in Terraform v0.15

### DIFF
--- a/tfupdate/provider_test.go
+++ b/tfupdate/provider_test.go
@@ -318,6 +318,41 @@ terraform {
 `,
 			ok: true,
 		},
+		{
+			src: `
+terraform {
+  required_providers {
+    aws = {
+      version = "2.65.0"
+      source  = "hashicorp/aws"
+
+      configuration_aliases = [
+        aws.primary,
+        aws.secondary,
+      ]
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    aws = {
+      version = "2.66.0"
+      source  = "hashicorp/aws"
+
+      configuration_aliases = [
+        aws.primary,
+        aws.secondary,
+      ]
+    }
+  }
+}
+`,
+			ok: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #40

The tfupdate mainly uses the hclwrite parser to preserve comments, but the hclwrite doesn't have enough AST for an object type, as a compromise, the tfupdate also uses the hclsyntax parser to detect old version.

Terraform v0.15 introduced a new configuration_aliases syntax.
https://www.terraform.io/upgrade-guides/0-15.html#alternative-provider-configurations-within-modules

It's not directly related version updating but it contains provider references and it causes a parse error without an EvalContext.

The ideal solution would be extending the hclwrite to be able to parse such a complicated object, but it's not realistic to expect it to be possible in the short term. So I decided to add a new hack on top of the existing hack to achieve the short term goal.

After seeking a temporary solution, I found that the terraform-config-inspect parses the configuration_aliases by using a hcl.ExprMap which doesn't require to decode fully references.

I feel the implementation is messy and fragile. It's probably better not to re-implement by ourselves and depend on the terraform-config-inspect.  However the terraform-config-inspect loads a root module not a file, and the current implementation of tfupdate detects and updates version in a single file. It's hard to use it for now. Using the terraform-config-inspect would require additional refactors for splitting the implementation to detecting and updating. To minimize the patch, I fixed only how to parse the required_providers block.