### PR TITLE
Fix panic when version key is quoted

### DIFF
--- a/tfupdate/provider.go
+++ b/tfupdate/provider.go
@@ -117,7 +117,13 @@ func (u *ProviderUpdater) updateTerraformRequiredProvidersBlockAsObject(p *hclwr
 
 	i := 0
 	// find key of version
-	for !(tokens[i].Type == hclsyntax.TokenIdent && string(tokens[i].Bytes) == "version") {
+	// Although not explicitly stated in the required_providers documentation,
+	// a TokenQuotedLit is also valid token. Strict speaking there are more
+	// variants because the left hand side of object key accepts an expression in
+	// HCL. For accurate implementation, it should be implemented using the
+	// original parser.
+	for !((tokens[i].Type == hclsyntax.TokenIdent || tokens[i].Type == hclsyntax.TokenQuotedLit) &&
+		string(tokens[i].Bytes) == "version") {
 		i++
 	}
 

--- a/tfupdate/provider_test.go
+++ b/tfupdate/provider_test.go
@@ -323,6 +323,31 @@ terraform {
 terraform {
   required_providers {
     aws = {
+      "version" = "2.65.0"
+      "source"  = "hashicorp/aws"
+    }
+  }
+}
+`,
+			name:    "aws",
+			version: "2.66.0",
+			want: `
+terraform {
+  required_providers {
+    aws = {
+      "version" = "2.66.0"
+      "source"  = "hashicorp/aws"
+    }
+  }
+}
+`,
+			ok: true,
+		},
+		{
+			src: `
+terraform {
+  required_providers {
+    aws = {
       version = "2.65.0"
       source  = "hashicorp/aws"
 


### PR DESCRIPTION
Fixes #51

Although not explicitly stated in the required_providers documentation, a TokenQuotedLit is also valid token for version.
Strict speaking there are more variants because the left hand side of object key accepts an expression in HCL.
For accurate implementation, it should be implemented using the original parser.