### PR TITLE
Use golangci instead of golint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: lint
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.43.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: test
-      run: make check
+      run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+# https://golangci-lint.run/usage/configuration/
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,5 @@
 NAME := tfupdate
 
-ifndef GOBIN
-GOBIN := $(shell echo "$${GOPATH%%:*}/bin")
-endif
-
-GOLINT := $(GOBIN)/golint
-
-$(GOLINT): ; @go install golang.org/x/lint/golint
-
 .DEFAULT_GOAL := build
 
 .PHONY: deps
@@ -23,16 +15,12 @@ install: deps
 	go install
 
 .PHONY: lint
-lint: $(GOLINT)
-	golint $$(go list ./... | grep -v /vendor/)
-
-.PHONY: vet
-vet:
-	go vet ./...
+lint:
+	golangci-lint run ./...
 
 .PHONY: test
-test: deps
+test: build
 	go test ./...
 
 .PHONY: check
-check: lint vet test build
+check: lint test

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/xanzy/go-gitlab v0.20.1
 	github.com/zclconf/go-cty v1.8.0
-	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 )
 
@@ -38,7 +37,6 @@ require (
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 // indirect
 	golang.org/x/text v0.3.5 // indirect
-	golang.org/x/tools v0.0.0-20190311212946-11955173bddd // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRK
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181108082009-03003ca0c849/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -113,8 +111,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/release/gitlab.go
+++ b/release/gitlab.go
@@ -50,7 +50,7 @@ func NewGitLabClient(config GitLabConfig) (*GitLabClient, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse gitlab base url: %s", err)
 		}
-		c.SetBaseURL(baseURL.String())
+		c.SetBaseURL(baseURL.String()) // nolint: errcheck
 	}
 
 	return &GitLabClient{

--- a/tfupdate/hclwrite_test.go
+++ b/tfupdate/hclwrite_test.go
@@ -129,7 +129,7 @@ service "label1" {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("%s", test.typeName), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", test.typeName), func(t *testing.T) { // nolint: gosimple
 			f, diags := hclwrite.ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
 			if len(diags) != 0 {
 				for _, diag := range diags {

--- a/tfupdate/update.go
+++ b/tfupdate/update.go
@@ -55,7 +55,7 @@ func UpdateHCL(r io.Reader, w io.Writer, filename string, o Option) (bool, error
 		return false, err
 	}
 
-	u.Update(f)
+	u.Update(f) // nolint: errcheck
 	output := f.BuildTokens(nil).Bytes()
 
 	if _, err := w.Write(output); err != nil {

--- a/tfupdate/update_test.go
+++ b/tfupdate/update_test.go
@@ -204,7 +204,7 @@ provider "aws" {
 			t.Errorf("UpdateHCL() with src = %s, o = %#v expects to return isUpdated = %t, but want = %t", tc.src, tc.o, isUpdated, tc.isUpdated)
 		}
 
-		got := string(w.Bytes())
+		got := string(w.Bytes()) // nolint: gosimple
 		if got != tc.want {
 			t.Errorf("UpdateHCL() with src = %s, o = %#v returns %s, but want = %s", tc.src, tc.o, got, tc.want)
 		}

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package tools
-
-import (
-	_ "golang.org/x/lint/golint" // executable dependency for development
-)


### PR DESCRIPTION
We have been using golint as a linter, but golint was officially deprecated.
golang/go#38968

The revive is a drop-in replacement of golint.
https://github.com/mgechev/revive

It's possible to use revive as it is, but I'd like to use revive via golangci-lint so that we can add more linters easily.
https://github.com/golangci/golangci-lint

The golangci-lint is a meta linter. I'll take this opportunity to introduce some additional checks.
I've suppressed all existing lint errors to pass CI. I'll fix them following PRs.