### PR TITLE
Add support for linux/arm64 Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -39,6 +41,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: docker run


### PR DESCRIPTION
When I ran tfupdate via Docker on my M1 Mac, the following message was output.

```shell
$ docker run -it --rm minamijoyo/tfupdate version
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

(Although this message is output, docker uses linux/amd64 Docker image and run it successfully.)

Therefore, we would like to create a linux/arm64 Docker image in GitHub Actions as well.

## Test

Run .github/workflow/docker.yml on the forked branch and see the following results

- [GitHub Actions Workflow should exit normally](https://github.com/kangaechu/tfupdate/runs/4797540986?check_suite_focus=true)
- linux/arm64 image is created in kangaechu/tfupdate
![image](https://user-images.githubusercontent.com/989985/149249275-15c2a3bb-47cc-4f63-a4fc-34c8654bfefa.png)

- Run tfupdate on M1 Mac and no warning should appear

```shell
$ docker run -it --rm kangaechu/tfupdate:add-support-for-linux-arm64-docker-image version
Unable to find image 'kangaechu/tfupdate:add-support-for-linux-arm64-docker-image' locally
add-support-for-linux-arm64-docker-image: Pulling from kangaechu/tfupdate
be307f383ecc: Pull complete
0dd357393144: Pull complete
a0f9577afe73: Pull complete
53d91f108910: Pull complete
Digest: sha256:2d764444d65ae7deefd308c070f6c8703ef38e1812ed749a90d0ea125980d552
Status: Downloaded newer image for kangaechu/tfupdate:add-support-for-linux-arm64-docker-image
Usage: tfupdate [--version] [--help] <command> [<args>]

Available commands are:
    module       Update version constraints for module
    provider     Update version constraints for provider
    release      Get release version information
    terraform    Update version constraints for terraform
```
