### PR TITLE
Fix go install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ https://github.com/minamijoyo/tfupdate/releases
 If you have Go 1.17+ development environment:
 
 ```
-$ git clone https://github.com/minamijoyo/tfupdate
-$ cd tfupdate/
-$ make install
+$ go install github.com/minamijoyo/tfupdate@latest
 $ tfupdate --version
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,3 @@ require (
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )
-
-// Fix invalid pseudo-version: revision is longer than canonical (b0274f40d4c7)
-replace github.com/go-macaron/cors => github.com/go-macaron/cors v0.0.0-20190925001837-b0274f40d4c7


### PR DESCRIPTION
Fixes #69

If go.mod contains a replace directive, go install results in an error.
The root cause of this problem is the following replace directive.
https://github.com/minamijoyo/tfupdate/blob/d7750d7619866f38cf2b7039718895f1f9962dc7/go.mod#L43-L44

This replace directive was introduced as a temporary workaround for the change of pseudo-version in Go 1.13.
https://github.com/minamijoyo/tfupdate/commit/31223822b1a54524c60ba15339338296d21fdfe4

Why did we depended on github.com/go-macaron/cors is that it was introduced by dependencies of goreleaser.
https://github.com/minamijoyo/tfupdate/commit/8eeb285b7237665846fb60b9df34920dda8778b9

However, we are currently using goreleaser via GitHub Actions, so we have already removed the goreleaser dependency from go.mod.
https://github.com/minamijoyo/tfupdate/commit/7f79068fdcc6d92184619617d17848b3ae1fb72f

That is, the replace directive is no longer needed, we can simply remove it.

before
```
$ go install github.com/minamijoyo/tfupdate@latest
go install: github.com/minamijoyo/tfupdate@latest (in github.com/minamijoyo/tfupdate@v0.6.4):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```

after (on this branch)
```
$ go install github.com/minamijoyo/tfupdate@fix-go-install
go: downloading github.com/minamijoyo/tfupdate v0.6.5-0.20220324012342-3e9b7ed50a5b

$ tfupdate -v
0.6.4
```