### PR TITLE
Update golangci-lint to v1.45.2 and actions to latest 

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        version: v1.43.0
+        go-version: 1.17.3
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.45.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,11 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.3
     - name: Run GoReleaser

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.17.3
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/tfupdate/module.go
+++ b/tfupdate/module.go
@@ -25,11 +25,11 @@ type ModuleUpdater struct {
 // NewModuleUpdater is a factory method which returns an ModuleUpdater instance.
 func NewModuleUpdater(name string, version string) (Updater, error) {
 	if len(name) == 0 {
-		return nil, errors.Errorf("failed to new module updater. name is required.")
+		return nil, errors.Errorf("failed to new module updater. name is required")
 	}
 
 	if len(version) == 0 {
-		return nil, errors.Errorf("failed to new module updater. version is required.")
+		return nil, errors.Errorf("failed to new module updater. version is required")
 	}
 
 	return &ModuleUpdater{

--- a/tfupdate/provider.go
+++ b/tfupdate/provider.go
@@ -19,11 +19,11 @@ type ProviderUpdater struct {
 // NewProviderUpdater is a factory method which returns an ProviderUpdater instance.
 func NewProviderUpdater(name string, version string) (Updater, error) {
 	if len(name) == 0 {
-		return nil, errors.Errorf("failed to new provider updater. name is required.")
+		return nil, errors.Errorf("failed to new provider updater. name is required")
 	}
 
 	if len(version) == 0 {
-		return nil, errors.Errorf("failed to new provider updater. version is required.")
+		return nil, errors.Errorf("failed to new provider updater. version is required")
 	}
 
 	return &ProviderUpdater{

--- a/tfupdate/terraform.go
+++ b/tfupdate/terraform.go
@@ -14,7 +14,7 @@ type TerraformUpdater struct {
 // NewTerraformUpdater is a factory method which returns an TerraformUpdater instance.
 func NewTerraformUpdater(version string) (Updater, error) {
 	if len(version) == 0 {
-		return nil, errors.Errorf("failed to new terraform updater. version is required.")
+		return nil, errors.Errorf("failed to new terraform updater. version is required")
 	}
 
 	return &TerraformUpdater{


### PR DESCRIPTION
The golangci/golangci-lint-action@v2 implicitly installs Go and its version was recently upgraded to Go 1.18. It causes an issue for old golangci-lint. To fix the problem either upgrading golangci-lint-action@v3 and setup Go 1.17.x explicitly or updating golangci-lint to the latest v1.45.2. I fixed both and also upgrading some actions to the latest.