### PR TITLE
Fix a regression issue for using absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ $ tfupdate lock --help
 Usage: tfupdate lock [options] <PATH>
 
 Arguments
-  PATH               A path of directory to update
+  PATH               A relative path of directory to update
 
 Options:
       --platform     Specify a platform to update dependency lock files.

--- a/command/lock.go
+++ b/command/lock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	"github.com/minamijoyo/tfupdate/tfupdate"
@@ -39,6 +40,12 @@ func (c *LockCommand) Run(args []string) int {
 
 	c.path = cmdFlags.Arg(0)
 
+	if filepath.IsAbs(c.path) {
+		c.UI.Error("The PATH argument should be a relative path, not an absolute path")
+		c.UI.Error(c.Help())
+		return 1
+	}
+
 	if len(c.platforms) == 0 {
 		c.UI.Error("The --platform flag is required")
 		c.UI.Error(c.Help())
@@ -73,7 +80,7 @@ func (c *LockCommand) Help() string {
 Usage: tfupdate lock [options] <PATH>
 
 Arguments
-  PATH               A path of directory to update
+  PATH               A relative path of directory to update
 
 Options:
       --platform     Specify a platform to update dependency lock files.


### PR DESCRIPTION
Fixes #93

A ModuleContext was introduced to support the lock command in tfupdate v0.7.0. This is intented to use the results of module inspection in any updaters, which is currently not used except for the lock command, but the inspection itself is enabled for all updaters.

When implementing this, there was a type miss match between afero and terraform-config-inspect filesystems. We worked around by using a compatibility layer via the standard io/fs.FS. However, it turned out that afero.IOFS does not support absolute paths. https://github.com/minamijoyo/tfupdate/issues/93

Ideally, it would be better to rewrite tests without afero, but it would require a lot of work. To fix the regression issue as quickly as we can, we will simply suppress the load error and add a validation for absolute path on the lock command side because we actually don't need this inspection result except for the lock command for now.