### PR TITLE
Fix a regression issue for updating .hcl file

### DIFF
--- a/tfupdate/file.go
+++ b/tfupdate/file.go
@@ -129,5 +129,7 @@ func UpdateFileOrDir(ctx context.Context, gc *GlobalContext, path string) error 
 	if err != nil {
 		return err
 	}
+	// When the filename is intentionally specified,
+	// we should not ignore it by its extension as much as possible.
 	return UpdateFile(ctx, mc, path)
 }

--- a/tfupdate/module.go
+++ b/tfupdate/module.go
@@ -43,8 +43,8 @@ func NewModuleUpdater(name string, version string) (Updater, error) {
 // Update updates the module version constraint.
 // Note that this method will rewrite the AST passed as an argument.
 func (u *ModuleUpdater) Update(_ context.Context, _ *ModuleContext, filename string, f *hclwrite.File) error {
-	if filepath.Ext(filename) != ".tf" {
-		// skip a file without .tf extension.
+	if filepath.Base(filename) == ".terraform.lock.hcl" {
+		// skip a lock file.
 		return nil
 	}
 

--- a/tfupdate/module_test.go
+++ b/tfupdate/module_test.go
@@ -158,40 +158,6 @@ module "vpc" {
 `,
 			ok: true,
 		},
-		{
-			filename: ".terraform.lock.hcl",
-			src: `
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.1"
-  constraints = "3.1.1"
-  hashes = [
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
-  ]
-}
-
-`,
-			name:    "git::https://example.com/vpc.git",
-			version: "1.3.0",
-			want: `
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.1"
-  constraints = "3.1.1"
-  hashes = [
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
-  ]
-}
-
-`,
-			ok: true,
-		},
 	}
 
 	for _, tc := range cases {

--- a/tfupdate/provider.go
+++ b/tfupdate/provider.go
@@ -37,8 +37,8 @@ func NewProviderUpdater(name string, version string) (Updater, error) {
 // Update updates the provider version constraint.
 // Note that this method will rewrite the AST passed as an argument.
 func (u *ProviderUpdater) Update(_ context.Context, _ *ModuleContext, filename string, f *hclwrite.File) error {
-	if filepath.Ext(filename) != ".tf" {
-		// skip a file without .tf extension.
+	if filepath.Base(filename) == ".terraform.lock.hcl" {
+		// skip a lock file.
 		return nil
 	}
 

--- a/tfupdate/terraform.go
+++ b/tfupdate/terraform.go
@@ -28,8 +28,8 @@ func NewTerraformUpdater(version string) (Updater, error) {
 // Update updates the terraform version constraint.
 // Note that this method will rewrite the AST passed as an argument.
 func (u *TerraformUpdater) Update(_ context.Context, _ *ModuleContext, filename string, f *hclwrite.File) error {
-	if filepath.Ext(filename) != ".tf" {
-		// skip a file without .tf extension.
+	if filepath.Base(filename) == ".terraform.lock.hcl" {
+		// skip a lock file.
 		return nil
 	}
 

--- a/tfupdate/terraform_test.go
+++ b/tfupdate/terraform_test.go
@@ -131,39 +131,6 @@ terraform {
 `,
 			ok: true,
 		},
-		{
-			filename: ".terraform.lock.hcl",
-			src: `
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.1"
-  constraints = "3.1.1"
-  hashes = [
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
-  ]
-}
-
-`,
-			version: "0.12.7",
-			want: `
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.1"
-  constraints = "3.1.1"
-  hashes = [
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
-  ]
-}
-
-`,
-			ok: true,
-		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #96

When the filename is intentionally specified, we should not ignore it by its extension as much as possible.

```
$ cat tmp/test.hcl
terraform {
  required_version = "1.5.0"
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "5.3.0"
    }
  }
}

$ go run main.go terraform -v 1.5.2 tmp/test.hcl

$ cat tmp/test.hcl
terraform {
  required_version = "1.5.2"
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "5.3.0"
    }
  }
}

$ go run main.go provider aws -v 5.7.0 tmp/test.hcl

$ cat tmp/test.hcl
terraform {
  required_version = "1.5.2"
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "5.7.0"
    }
  }
}
```