### PR TITLE
Add support for provider namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,12 @@ $ tfupdate provider --help
 Usage: tfupdate provider [options] <PROVIDER_NAME> <PATH>
 
 Arguments
-  PROVIDER_NAME      A name of provider (e.g. aws, google, azurerm)
+  PROVIDER_NAME      A name of provider (e.g. aws or integrations/github)
   PATH               A path of file or directory to update
 
 Options:
   -v  --version      A new version constraint (default: latest)
                      If the version is omitted, the latest version is automatically checked and set.
-                     Getting the latest version automatically is supported only for official providers.
-                     If you have an unofficial provider, use release latest command.
   -r  --recursive    Check a directory recursively (default: false)
   -i  --ignore-path  A regular expression for path to ignore
                      If you want to ignore multiple directories, set the flag multiple times.

--- a/command/provider.go
+++ b/command/provider.go
@@ -44,7 +44,13 @@ func (c *ProviderCommand) Run(args []string) int {
 
 	v := c.version
 	if v == "latest" {
-		source := fmt.Sprintf("terraform-providers/terraform-provider-%s", c.name)
+		source := ""
+		if strings.Contains(c.name, "/") {
+			namespace, name, _ := strings.Cut(c.name, "/")
+			source = fmt.Sprintf("%s/terraform-provider-%s", namespace, name)
+		} else {
+			source = fmt.Sprintf("hashicorp/terraform-provider-%s", c.name)
+		}
 		r, err := newRelease("github", source)
 		if err != nil {
 			c.UI.Error(err.Error())
@@ -86,14 +92,12 @@ func (c *ProviderCommand) Help() string {
 Usage: tfupdate provider [options] <PROVIDER_NAME> <PATH>
 
 Arguments
-  PROVIDER_NAME      A name of provider (e.g. aws, google, azurerm)
+  PROVIDER_NAME      A name of provider (e.g. aws or integrations/github)
   PATH               A path of file or directory to update
 
 Options:
   -v  --version      A new version constraint (default: latest)
                      If the version is omitted, the latest version is automatically checked and set.
-                     Getting the latest version automatically is supported only for official providers.
-                     If you have an unofficial provider, use release latest command.
   -r  --recursive    Check a directory recursively (default: false)
   -i  --ignore-path  A regular expression for path to ignore
                      If you want to ignore multiple directories, set the flag multiple times.

--- a/tfupdate/context.go
+++ b/tfupdate/context.go
@@ -181,3 +181,16 @@ func selectVersion(constraints []string) string {
 	}
 	return ""
 }
+
+// ResolveProviderShortNameFromSource is a helper function to resolve provider
+// short names from the source address.
+// If not found, return an empty string.
+func (mc *ModuleContext) ResolveProviderShortNameFromSource(source string) string {
+	for k, v := range mc.requiredProviders {
+		if v.Source == source {
+			return k
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
Fixes #99

The current implementation of `tfupdate provider <PROVIDER_NAME>` uses the `<PROVIDER_NAME>` argument as a key for the `required_providers` block. To support namespaces, we also need to check the `source` attribute. The most important point is that the key can be almost any string but cannot contain `/`. Thus, if the argument contains `/`, we can assume that the user intends to use namespaces and check the `source` attribute. To maintain backward compatibility of tfupdate, when namespaces are omitted, `hashicorp/` should not be implicitly assumed.

In addition, if a version is omitted when updating providers, we use the namespace as a GitHub namespace and fetch the latest version. This is based on some implicit habitual assumptions and may not be accurate. Still, we continue to use GitHub as a release source because we rely on GitHub's redirects when namespaces are omitted.

One concern is that it is unclear how long the legacy terraform-providers/ org redirects will be maintained. I will take this opportunity to switch it to the current hashicorp/ org.

Thus, namespaces must be explicit for legacy partner providers if all of the following conditions are met:

- The tfupdate provider command does not explicitly specify the namespace.
- The tfupdate provider command does not explicitly specify the version.
- Redirected from legacy terraform-providers/ org to partner org on GitHub.
- Hosted not under hashicorp/ org on GitHub and not redirected to partner org on GitHub.

This could be a breaking change to a small number of partner provider users, but the impact is limited, so it has been fixed how it should be.

```
$ cat main.tf
terraform {
  required_providers {
    github = {
      source  = "integrations/github"
      version = "5.38.0"
    }
  }
}

$ tfupdate provider integrations/github main.tf

$ cat main.tf
terraform {
  required_providers {
    github = {
      source  = "integrations/github"
      version = "5.39.0"
    }
  }
}
```