### PR TITLE
Fixed a crash when parsing invalid release versions as SemVer

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -33,18 +33,20 @@ func Latest(ctx context.Context, r Release) (string, error) {
 // List returns a list of releases in semver order.
 // If preRelease is set to false, the result doesn't contain pre-releases.
 func List(ctx context.Context, r Release, maxLength int, preRelease bool) ([]string, error) {
-	versions, err := r.ListReleases(ctx)
+	res, err := r.ListReleases(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	versions := toVersions(res)
 	sorted := sortVersions(versions)
-	releases := sorted
+	rels := sorted
 
 	if !preRelease {
-		releases = excludePreReleases(sorted)
+		rels = excludePreReleases(sorted)
 	}
 
+	releases := fromVersions(rels)
 	start := len(releases) - minInt(maxLength, len(releases))
 	return releases[start:], nil
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -61,6 +61,15 @@ func TestLatest(t *testing.T) {
 			want: "",
 			ok:   false,
 		},
+		{
+			desc: "parse error",
+			r: &mockRelease{
+				versions: []string{"foo", "0.3.0", "0.2.0", "0.1.0", "0.1.1"},
+				err:      nil,
+			},
+			want: "0.3.0",
+			ok:   true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/release/version.go
+++ b/release/version.go
@@ -31,17 +31,21 @@ func minInt(a, b int) int {
 	return b
 }
 
-// toVersions converts []string to []*version.Version
+// toVersions converts []string to []*version.Version.
+// Ignore if parse error.
 func toVersions(versionsRaw []string) []*version.Version {
-	versions := make([]*version.Version, len(versionsRaw))
-	for i, raw := range versionsRaw {
-		v, _ := version.NewVersion(raw)
-		versions[i] = v
+	versions := []*version.Version{}
+	for _, raw := range versionsRaw {
+		v, err := version.NewVersion(raw)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
 	}
 	return versions
 }
 
-// fromVersions converts []*version.Version to []string
+// fromVersions converts []*version.Version to []string.
 func fromVersions(versions []*version.Version) []string {
 	versionsRaw := make([]string, len(versions))
 	for i, v := range versions {
@@ -52,19 +56,13 @@ func fromVersions(versions []*version.Version) []string {
 }
 
 // sortVersions sort a list of versions in semver order.
-func sortVersions(versionsRaw []string) []string {
-	versions := toVersions(versionsRaw)
-
-	// sort them in semver order
+func sortVersions(versions []*version.Version) []*version.Version {
 	sort.Sort(version.Collection(versions))
-
-	return fromVersions(versions)
+	return versions
 }
 
 // excludePreReleases excludes pre-releases such as alpha, beta, rc.
-func excludePreReleases(versionsRaw []string) []string {
-	versions := toVersions(versionsRaw)
-
+func excludePreReleases(versions []*version.Version) []*version.Version {
 	// exclude pre-release
 	filtered := []*version.Version{}
 	for _, v := range versions {
@@ -73,5 +71,5 @@ func excludePreReleases(versionsRaw []string) []string {
 		}
 	}
 
-	return fromVersions(filtered)
+	return filtered
 }

--- a/release/version_test.go
+++ b/release/version_test.go
@@ -30,7 +30,7 @@ func TestSortVersions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := sortVersions(tc.versionsRaw)
+			got := fromVersions(sortVersions(toVersions(tc.versionsRaw)))
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got = %#v, but want = %#v", got, tc.want)
 			}
@@ -68,7 +68,7 @@ func TestExcludePreReleases(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := excludePreReleases(tc.versionsRaw)
+			got := fromVersions(excludePreReleases(toVersions(tc.versionsRaw)))
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got = %#v, but want = %#v", got, tc.want)
 			}


### PR DESCRIPTION
Release tags that did not follow SemVer would result in parse errors, but error handling was not being done correctly and resulted in panic by nil references in sortVersions().

For examples:
https://github.com/winebarrel/terraform-provider-mysql/releases/tag/mysqlx-v1.9.0-0

```
$ go run main.go release latest winebarrel/terraform-provider-mysql
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x100bbbdf4]

goroutine 1 [running]:
github.com/hashicorp/go-version.(*Version).String(0x0)
        /Users/minamijoyo/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:369 +0x34
github.com/hashicorp/go-version.(*Version).Compare(0x0, 0x14000290960)
        /Users/minamijoyo/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:116 +0x24
github.com/hashicorp/go-version.(*Version).LessThan(...)
        /Users/minamijoyo/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:308
github.com/hashicorp/go-version.Collection.Less(...)
        /Users/minamijoyo/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version_collection.go:12
sort.partition({0x1011f3ce8, 0x140004853c8}, 0x0, 0x14, 0x1400022fbe8?)
        /Users/minamijoyo/.asdf/installs/golang/1.21.1/go/src/sort/zsortinterface.go:142 +0xc0
sort.pdqsort({0x1011f3ce8, 0x140004853c8}, 0x18?, 0x1010d93e0?, 0x140004c6101?)
        /Users/minamijoyo/.asdf/installs/golang/1.21.1/go/src/sort/zsortinterface.go:114 +0x1ac
sort.Sort({0x1011f3ce8, 0x140004853c8})
        /Users/minamijoyo/.asdf/installs/golang/1.21.1/go/src/sort/sort.go:51 +0x60
github.com/minamijoyo/tfupdate/release.sortVersions({0x140004c6000?, 0x1011f4610?, 0x1015fa2a0?})
        /Users/minamijoyo/src/github.com/minamijoyo/tfupdate/release/version.go:59 +0x40
github.com/minamijoyo/tfupdate/release.List({0x1011f4610?, 0x1015fa2a0?}, {0x1011f0700?, 0x1400011d9e0?}, 0x1, 0x0)
        /Users/minamijoyo/src/github.com/minamijoyo/tfupdate/release/release.go:41 +0x4c
github.com/minamijoyo/tfupdate/release.Latest({0x1011f4610?, 0x1015fa2a0?}, {0x1011f0700?, 0x1400011d9e0?})
        /Users/minamijoyo/src/github.com/minamijoyo/tfupdate/release/release.go:21 +0x34
github.com/minamijoyo/tfupdate/command.(*ReleaseLatestCommand).Run(0x1400013d200, {0x1400013c030, 0x1, 0x1})
        /Users/minamijoyo/src/github.com/minamijoyo/tfupdate/command/release_latest.go:43 +0x1b8
github.com/mitchellh/cli.(*CLI).Run(0x14000182dc0)
        /Users/minamijoyo/pkg/mod/github.com/mitchellh/cli@v1.0.0/cli.go:255 +0x4a8
main.main()
        /Users/minamijoyo/src/github.com/minamijoyo/tfupdate/main.go:47 +0x204
exit status 2

```
