### PR TITLE
Pin goreleaser to v1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,9 @@ jobs:
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
         repository: minamijoyo/homebrew-tfupdate
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v6
       with:
-        version: latest
+        version: "~> v1"
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed that the release flow is broken. It appears that the --rm-dist flag was removed in goreleaser v2. We need to investigate the details later, but I will pin it to v1 for now.