### PR TITLE
Update goreleaser to v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,8 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
-        version: "~> v1"
-        args: release --rm-dist
+        version: "~> v2"
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.generate_github_app_token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
-# .goreleaser.yml
-# Build customization
+version: 2
 builds:
   - binary: tfupdate
     goos:
@@ -21,7 +20,7 @@ changelog:
       - Update README
       - Update CHANGELOG
 brews:
-  - tap:
+  - repository:
       owner: minamijoyo
       name: homebrew-tfupdate
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
The GoReleaser v2 includes several breaking changes.
I followed the upgrade guide and fixed the settings.

https://goreleaser.com/blog/goreleaser-v2/
https://goreleaser.com/deprecations/#removed-in-v2