### PR TITLE
Allow TFREGISTRY_BASE_URL to set the host of the Terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,12 +346,6 @@ Arguments
                        - tfregistryProvider:
                          namespace/type
                          e.g. hashicorp/aws
-                       - opentofuRegistryModule:
-                         namespace/name/provider
-                         e.g. terraform-aws-modules/vpc/aws
-                       - opentofuRegistryProvider:
-                         namespace/type
-                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -360,8 +354,6 @@ Options:
                        - gitlab
                        - tfregistryModule
                        - tfregistryProvider
-                       - opentofuRegistryModule
-                       - opentofuRegistryProvider
 ```
 
 ```
@@ -372,6 +364,8 @@ $ tfupdate release latest terraform-providers/terraform-provider-aws
 If you want to access private repositories on GitHub, export your access token to the `GITHUB_TOKEN` environment variable.
 
 If you want to access public or private repositories on GitLab, export your access token with api permissions to the `GITLAB_TOKEN` environment variable. If you are using an instance that is not `https://gitlab.com`, set the correct base URL to the `GITLAB_BASE_URL` environment variable (defaults to `https://gitlab.com/api/v4/`).
+
+If you want to use the public OpenTofu registry, set the `TFREGISTRY_BASE_URL` environment variable to `https://registry.opentofu.org/`.
 
 ```
 $ tfupdate release list --help
@@ -389,12 +383,6 @@ Arguments
                        - tfregistryProvider:
                          namespace/type
                          e.g. hashicorp/aws
-                       - opentofuRegistryModule:
-                         namespace/name/provider
-                         e.g. terraform-aws-modules/vpc/aws
-                       - opentofuRegistryProvider:
-                         namespace/type
-                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -403,8 +391,6 @@ Options:
                        - gitlab
                        - tfregistryModule
                        - tfregistryProvider
-                       - opentofuRegistryModule
-                       - opentofuRegistryProvider
   -n  --max-length   The maximum length of list.
 ```
 

--- a/command/env.go
+++ b/command/env.go
@@ -2,16 +2,20 @@ package command
 
 // Env is a set of configurations read from environment variables.
 type Env struct {
-	// GitHubBaseURL is a URL for GtiHub API requests.
+	// GitHubBaseURL is a base URL for GtiHub API requests.
 	// Defaults to the public GitHub API.
 	GitHubBaseURL string `envconfig:"GITHUB_BASE_URL" default:"https://api.github.com/"`
 	// GitHubToken is a personal access token for GitHub.
 	// This allows access to a private repository.
 	GitHubToken string `envconfig:"GITHUB_TOKEN"`
-	// GitLabBaseURL is a URL for GitLab API requests.
+	// GitLabBaseURL is a base URL for GitLab API requests.
 	// Defaults to the public GitLab API.
 	GitLabBaseURL string `envconfig:"GITLAB_BASE_URL" default:"https://gitlab.com/api/v4/"`
 	// GitLabToken is a personal access token for GitLab.
 	// This is needed for public and private projects on all instances.
 	GitLabToken string `envconfig:"GITLAB_TOKEN"`
+	// TFRegistryBaseURL is a base URL for Terraform registry.
+	// Defaults to the public Terraform registry.
+	// To use the public OpenTofu registry, set this to `https://registry.opentofu.org/`.
+	TFRegistryBaseURL string `envconfig:"TFREGISTRY_BASE_URL" default:"https://registry.terraform.io/"`
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -40,16 +40,14 @@ func newRelease(sourceType string, source string) (release.Release, error) {
 		}
 		return release.NewGitLabRelease(source, config)
 	case "tfregistryModule":
-		config := release.NewDefaultTerraformRegistryConfig()
+		config := release.TFRegistryConfig{
+			BaseURL: env.TFRegistryBaseURL,
+		}
 		return release.NewTFRegistryModuleRelease(source, config)
 	case "tfregistryProvider":
-		config := release.NewDefaultTerraformRegistryConfig()
-		return release.NewTFRegistryProviderRelease(source, config)
-	case "opentofuRegistryModule":
-		config := release.NewDefaultOpenTofuRegistryConfig()
-		return release.NewTFRegistryModuleRelease(source, config)
-	case "opentofuRegistryProvider":
-		config := release.NewDefaultOpenTofuRegistryConfig()
+		config := release.TFRegistryConfig{
+			BaseURL: env.TFRegistryBaseURL,
+		}
 		return release.NewTFRegistryProviderRelease(source, config)
 	default:
 		return nil, fmt.Errorf("failed to new release data source. unknown type: %s", sourceType)

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -67,12 +67,6 @@ Arguments
                        - tfregistryProvider:
                          namespace/type
                          e.g. hashicorp/aws
-                       - opentofuRegistryModule:
-                         namespace/name/provider
-                         e.g. terraform-aws-modules/vpc/aws
-                       - opentofuRegistryProvider:
-                         namespace/type
-                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -81,8 +75,6 @@ Options:
                        - gitlab
                        - tfregistryModule
                        - tfregistryProvider
-                       - opentofuRegistryModule
-                       - opentofuRegistryProvider
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -71,12 +71,6 @@ Arguments
                        - tfregistryProvider:
                          namespace/type
                          e.g. hashicorp/aws
-                       - opentofuRegistryModule:
-                         namespace/name/provider
-                         e.g. terraform-aws-modules/vpc/aws
-                       - opentofuRegistryProvider:
-                         namespace/type
-                         e.g. hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -85,8 +79,6 @@ Options:
                        - gitlab
                        - tfregistryModule
                        - tfregistryProvider
-                       - opentofuRegistryModule
-                       - opentofuRegistryProvider
   -n  --max-length   The maximum length of list.
       --pre-release  Show pre-releases. (default: false)
 `

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -34,22 +34,6 @@ type TFRegistryConfig struct {
 	BaseURL string
 }
 
-// NewDefaultTerraformRegistryConfig returns a TFRegistryConfig with the default
-// BaseURL for the public Terraform Registry.
-func NewDefaultTerraformRegistryConfig() TFRegistryConfig {
-	return TFRegistryConfig{
-		BaseURL: "https://registry.terraform.io/",
-	}
-}
-
-// NewDefaultOpenTofuRegistryConfig returns a TFRegistryConfig with the default
-// BaseURL for the public OpenTofu Registry.
-func NewDefaultOpenTofuRegistryConfig() TFRegistryConfig {
-	return TFRegistryConfig{
-		BaseURL: "https://registry.opentofu.org/",
-	}
-}
-
 // TFRegistryClient is a real TFRegistryAPI implementation.
 type TFRegistryClient struct {
 	client *tfregistry.Client


### PR DESCRIPTION
In #130, I added opentofuRegistryModule and opentofuRegistryProvider to the --source type in the release latest and list commands, but it turned out that this was not a good design.

When considering OpenTofu support for the lock command, I noticed that the lock file records the hostname of the registry. However, this cannot be retrieved from the required_providers block. We could pass the hostname as an argument, but GitHub and GitLab already allow the BaseURL to be passed from an environment variable, so it would be better to align it with this.

Also, opentofuRegistryModule and opentofuRegistryProvider only replace BaseURL and call compatible APIs at the protocol level. They are redundant and should be removed before cutting a new release.