### PR TITLE
Fix the build issue with the replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-config-inspect v0.0.0-20230614215431-f32df32a01cd
 	github.com/hashicorp/terraform-registry-address v0.2.0
+	github.com/hashicorp/terraform-svchost v0.0.1
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/minamijoyo/terraform-config-inspect v0.0.0-20250505010908-6ad6eb27d3c9
 	github.com/mitchellh/cli v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.9.5
@@ -34,7 +35,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f // indirect
-	github.com/hashicorp/terraform-svchost v0.0.1 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
@@ -47,5 +47,3 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/hashicorp/terraform-config-inspect => github.com/minamijoyo/terraform-config-inspect v0.0.0-20250409132015-3abe93bba59a

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/minamijoyo/terraform-config-inspect v0.0.0-20250409132015-3abe93bba59a h1:2aVB3JExTvAKu3oa68OYRpgHeU/lW6qq0DDNKEN494w=
-github.com/minamijoyo/terraform-config-inspect v0.0.0-20250409132015-3abe93bba59a/go.mod h1:Gz/z9Hbn+4KSp8A2FBtNszfLSdT2Tn/uAKGuVqqWmDI=
+github.com/minamijoyo/terraform-config-inspect v0.0.0-20250505010908-6ad6eb27d3c9 h1:6trjsdYNQsBXv9BShavPR047w/ufWQ6CnzlGO/nd2vo=
+github.com/minamijoyo/terraform-config-inspect v0.0.0-20250505010908-6ad6eb27d3c9/go.mod h1:RhDzenR6+Mj5hmOQpw0nOiMTPDTrjLfuYAtxvcq2IVY=
 github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=

--- a/tfupdate/context.go
+++ b/tfupdate/context.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/minamijoyo/terraform-config-inspect/tfconfig"
 	"github.com/spf13/afero"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"


### PR DESCRIPTION
Fixes #135

When I used a forked version of hashicorp/terraform-config-inspect to support the .tofu extension in #128, I had forgotten that the replace directive does not work when go install from outside the repository.

So far, I have not found a reliable OpenTofu equivalent of terraform-config-inspect, and there is no possibility that the forked version will be merged into upstream.

In general, changing the import path can cause conflicts with upstream, but fortunately, it is not used in too many places. I'm waiting for the official OpenTofu version to be released, but for now, I'll align the import path with the forked version and remove the replace directive.

https://github.com/minamijoyo/terraform-config-inspect/commit/6ad6eb27d3c9437faaf5e0f793f3892701a90ada