### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+The security policy for this project is as follows.
+
+## General
+This project is open source and is provided "as is."
+
+We will do our best to address security issues, but the project maintainers make no guarantees regarding whether or when they will be addressed. We appreciate your understanding and cooperation.
+
+## Supported versions
+This project only supports the latest version. We do not provide security patches for previous versions.
+
+## Policy for fixing known vulnerabilities in dependency libraries
+This project uses the "Dependabot alerts" and "Dependabot security updates" features to manage known vulnerabilities in dependency libraries. We will address vulnerabilities in dependency libraries as appropriate, so there is no need to report them as new vulnerabilities in this project. If Dependabot is not working properly for some reason, feel free to create a pull request. For the issue that has already been made public, we don't need to discuss it privately.
+
+We do not provide patch releases for every issue we fix, except for critical ones. Instead, we release multiple fixes together as a patch. The severity is determined based on whether it is critical for this project, not the score reported for the dependency library.
+
+## How to report a security issue privately
+If you discover a security issue in this project, please refrain from reporting it using a public issue. Instead, please use GitHub's "Private vulnerability reporting" feature to report it.
+
+https://github.com/minamijoyo/tfupdate/security/advisories


### PR DESCRIPTION
This is a follow-up to #142.

This project began about six years ago as my side project and has been maintained to today, but it seems to be used more widely than I had imagined.

I understand that companies that utilize Terraform with tfupdate need to maintain a certain level of governance. I also understand that it is more valuable to have vulnerabilities managed than to worry about whether the issues detected by security scanners could actually lead to meaningful attacks.

Personally, I have avoided using Dependabot for hobby projects because the maintenance costs are too high. Even now, I am not confident that I can properly manage it in my spare time. However, I have reconsidered and decided that it is sufficient to do my best within the limits of what is possible, even if it is not perfect.

At the end, I have enabled “Dependabot alerts,” “Dependabot security updates,” and “Private vulnerability reporting.”
 
I have documented the policy to align expectations with the community. If it does not work well, I will reconsider it at that time.