### PR TITLE
Skip downloading binaries if the registry supports h1 hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,11 @@ Arguments
 
 Options:
       --platform     Specify a platform to update dependency lock files.
-                     At least one or more --platform flags must be specified.
                      Use this option multiple times to include checksums for multiple target systems.
                      Target platform names consist of an operating system and a CPU architecture.
                      (e.g. linux_amd64, darwin_amd64, darwin_arm64)
+                     If the registry supports h1 hash values, as in the public OpenTofu Registry, omitting
+                     the platform will record hash values for all platforms without downloading binaries.
   -r  --recursive    Check a directory recursively (default: false)
   -i  --ignore-path  A regular expression for path to ignore
                      If you want to ignore multiple directories, set the flag multiple times.
@@ -538,6 +539,8 @@ provider "registry.terraform.io/hashicorp/null" {
 The tfupdate lock command parses the `required_providers` block in your configuration, downloads provider packages and calculates hash values under the hood. The most important point is that it caches calculated hash values in memory, which gives us a huge performance advantage when updating multiple directories at once using the `-r (--recursive)` option.
 
 To skip terraform init, we assume that all dependencies are pinned to a specific version in the required_providers block of the root module. Note that version constraint expressions or indirect dependencies via modules are not supported and ignored.
+
+If the registry supports h1 hash values, as in the public OpenTofu Registry, omitting the platform will record hash values for all platforms without downloading binaries.
 
 ## Keep your dependencies up-to-date
 

--- a/command/lock.go
+++ b/command/lock.go
@@ -48,12 +48,6 @@ func (c *LockCommand) Run(args []string) int {
 		return 1
 	}
 
-	if len(c.platforms) == 0 {
-		c.UI.Error("The --platform flag is required")
-		c.UI.Error(c.Help())
-		return 1
-	}
-
 	log.Println("[INFO] Update dependency lock files")
 
 	// Fetch environment variables
@@ -100,10 +94,11 @@ Arguments
 
 Options:
       --platform     Specify a platform to update dependency lock files.
-                     At least one or more --platform flags must be specified.
                      Use this option multiple times to include checksums for multiple target systems.
                      Target platform names consist of an operating system and a CPU architecture.
                      (e.g. linux_amd64, darwin_amd64, darwin_arm64)
+                     If the registry supports h1 hash values, as in the public OpenTofu Registry, omitting
+                     the platform will record hash values for all platforms without downloading binaries.
   -r  --recursive    Check a directory recursively (default: false)
   -i  --ignore-path  A regular expression for path to ignore
                      If you want to ignore multiple directories, set the flag multiple times.

--- a/lock/hash_test.go
+++ b/lock/hash_test.go
@@ -40,6 +40,13 @@ func TestZipDataToH1Hash(t *testing.T) {
 			ok:       true,
 		},
 		{
+			desc:     "windows_amd64",
+			makeZip:  true,
+			contents: "dummy_3.2.1_windows_amd64",
+			want:     "h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
+			ok:       true,
+		},
+		{
 			desc:     "invalid zip format",
 			makeZip:  false,
 			contents: "dummy_3.2.1_linux_amd64",

--- a/lock/index.go
+++ b/lock/index.go
@@ -34,8 +34,8 @@ type index struct {
 	// It can be replaced for testing.
 	tfrapi tfregistry.API
 
-	// papi is a ProviderDownloaderAPI interface implementation used for downloading provider.
-	papi ProviderDownloaderAPI
+	// papi is a ProviderLockAPI interface implementation used for locking provider.
+	papi ProviderLockAPI
 }
 
 // NewIndexFromConfig returns a new instance of Index with the given registry config.
@@ -45,7 +45,7 @@ func NewIndexFromConfig(config tfregistry.Config) (Index, error) {
 		return nil, err
 	}
 
-	client, err := NewProviderDownloaderClient(config)
+	client, err := NewProviderLockClient(config)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func NewIndexFromConfig(config tfregistry.Config) (Index, error) {
 }
 
 // NewIndex returns a new instance of Index with the given provider downloader API.
-func NewIndex(tfrapi tfregistry.API, papi ProviderDownloaderAPI) Index {
+func NewIndex(tfrapi tfregistry.API, papi ProviderLockAPI) Index {
 	providers := make(map[string]*providerIndex)
 	return &index{
 		providers: providers,
@@ -91,12 +91,12 @@ type providerIndex struct {
 	// It can be replaced for testing.
 	tfrapi tfregistry.API
 
-	// papi is a ProviderDownloaderAPI interface implementation used for downloading provider.
-	papi ProviderDownloaderAPI
+	// papi is a ProviderLockAPI interface implementation used for locking provider.
+	papi ProviderLockAPI
 }
 
 // newProviderIndex returns a new instance of providerIndex.
-func newProviderIndex(address string, tfrapi tfregistry.API, papi ProviderDownloaderAPI) *providerIndex {
+func newProviderIndex(address string, tfrapi tfregistry.API, papi ProviderLockAPI) *providerIndex {
 	versions := make(map[string]*ProviderVersion)
 	return &providerIndex{
 		address:  address,
@@ -272,7 +272,7 @@ func parseProviderAddress(address string) (*tfaddr.Provider, error) {
 	// We parse an provider address by using the terraform-registry-address
 	// library to support fully qualified addresses such as
 	// registry.terraform.io/hashicorp/null in the future, but note that the
-	// current ProviderDownloaderClient implementation only supports the public
+	// current ProviderLockClient implementation only supports the public
 	// standard registry (registry.terraform.io).
 	pAddr, err := tfaddr.ParseProviderSource(address)
 	if err != nil {

--- a/lock/index.go
+++ b/lock/index.go
@@ -254,7 +254,7 @@ func buildProviderVersionFromPackageMetadata(address string, version string, res
 		}
 	}
 
-	platforms := slices.Collect(maps.Keys(res.Packages))
+	platforms := slices.Sorted(maps.Keys(res.Packages))
 	pv := &ProviderVersion{
 		address:   address,
 		version:   version,

--- a/lock/index.go
+++ b/lock/index.go
@@ -233,11 +233,21 @@ func buildProviderVersionFromPackageMetadata(address string, version string, res
 	zhHashes := make(map[string]string)
 
 	for platform, pkg := range res.Packages {
+		// Historically, the zh hash in the Terraform Registry contains `manifest.json`,
+		// so the key for the `ProviderVersion` map is `filename`, not `platform`.
+		// To ensure the same results with Terraform and OpenTofu,
+		// we need to build filename for each platform.
+		// e.g.) darwin_arm64 => terraform-provider-null_3.2.1_darwin_arm64.zip
+		pAddr, err := parseProviderAddress(address)
+		if err != nil {
+			return nil, err
+		}
+		filename := fmt.Sprintf("terraform-provider-%s_%s_%s.zip", pAddr.Type, version, platform)
 		for _, h := range pkg.Hashes {
 			if strings.HasPrefix(h, "h1:") {
-				h1Hashes[platform] = h
+				h1Hashes[filename] = h
 			} else if strings.HasPrefix(h, "zh:") {
-				zhHashes[platform] = h
+				zhHashes[filename] = h
 			} else {
 				return nil, fmt.Errorf("unknown hash type: %s", h)
 			}

--- a/lock/index.go
+++ b/lock/index.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
+	"runtime"
+	"slices"
 	"strings"
 
 	tfaddr "github.com/hashicorp/terraform-registry-address"
@@ -27,27 +30,37 @@ type index struct {
 	// The key is a provider address such as hashicorp/null.
 	providers map[string]*providerIndex
 
+	// tfrapi is an instance of tfregistry.API interface.
+	// It can be replaced for testing.
+	tfrapi tfregistry.API
+
 	// papi is a ProviderDownloaderAPI interface implementation used for downloading provider.
 	papi ProviderDownloaderAPI
 }
 
 // NewIndexFromConfig returns a new instance of Index with the given registry config.
 func NewIndexFromConfig(config tfregistry.Config) (Index, error) {
+	tfrapi, err := tfregistry.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := NewProviderDownloaderClient(config)
 	if err != nil {
 		return nil, err
 	}
 
-	index := NewIndex(client)
+	index := NewIndex(tfrapi, client)
 
 	return index, nil
 }
 
 // NewIndex returns a new instance of Index with the given provider downloader API.
-func NewIndex(papi ProviderDownloaderAPI) Index {
+func NewIndex(tfrapi tfregistry.API, papi ProviderDownloaderAPI) Index {
 	providers := make(map[string]*providerIndex)
 	return &index{
 		providers: providers,
+		tfrapi:    tfrapi,
 		papi:      papi,
 	}
 }
@@ -58,7 +71,7 @@ func (i *index) GetOrCreateProviderVersion(ctx context.Context, address string, 
 	pi, ok := i.providers[address]
 	if !ok {
 		// cache miss
-		pi = newProviderIndex(address, i.papi)
+		pi = newProviderIndex(address, i.tfrapi, i.papi)
 		i.providers[address] = pi
 	}
 	// Delegate to ProviderIndex.
@@ -74,16 +87,21 @@ type providerIndex struct {
 	// The key is a version number such as 3.2.1.
 	versions map[string]*ProviderVersion
 
+	// tfrapi is an instance of tfregistry.API interface.
+	// It can be replaced for testing.
+	tfrapi tfregistry.API
+
 	// papi is a ProviderDownloaderAPI interface implementation used for downloading provider.
 	papi ProviderDownloaderAPI
 }
 
 // newProviderIndex returns a new instance of providerIndex.
-func newProviderIndex(address string, papi ProviderDownloaderAPI) *providerIndex {
+func newProviderIndex(address string, tfrapi tfregistry.API, papi ProviderDownloaderAPI) *providerIndex {
 	versions := make(map[string]*ProviderVersion)
 	return &providerIndex{
 		address:  address,
 		versions: versions,
+		tfrapi:   tfrapi,
 		papi:     papi,
 	}
 }
@@ -107,8 +125,29 @@ func (pi *providerIndex) getOrCreateProviderVersion(ctx context.Context, version
 // createProviderVersion downloads the specified provider, calculates the hash
 // value and returns an instance of the ProviderVersion.
 func (pi *providerIndex) createProviderVersion(ctx context.Context, version string, platforms []string) (*ProviderVersion, error) {
-	ret := newEmptyProviderVersion(pi.address, version)
+	// Starting with OpenTofu v1.12, the OpenTofu Registry now returns both the
+	// zh hash and the precomputed h1 hash, so fetching only the metadata allows
+	// us to skip downloading the provider’s binary.
+	// If the platform is omitted, we assume that the registry metadata returns the h1 hash values for all platforms.
+	if len(platforms) == 0 {
+		// The metadata request returns hash values for all platforms, but we need to specify a platform when making the call.
+		platform := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
 
+		pv, err := pi.fetchProviderPackageMetadata(ctx, version, platform)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(pv.h1Hashes) != 0 && len(pv.zhHashes) != 0 {
+			// If both the h1 and zh hashes are available, we can skip downloading the provider binary.
+			log.Printf("[DEBUG] providerIndex.createProviderVersion: %s, %s. The registry returns both h1 and zh hashes. Skipping provider download.", pi.address, version)
+			return pv, nil
+		} else {
+			return nil, fmt.Errorf("failed to fetch provider package metadata for %s %s. The registry does not support h1 hashes. Please specify the platform on which the hash value should be calculated.", pi.address, version)
+		}
+	}
+
+	ret := newEmptyProviderVersion(pi.address, version)
 	for _, platform := range platforms {
 		req, err := newProviderDownloadRequest(pi.address, version, platform)
 		if err != nil {
@@ -125,7 +164,7 @@ func (pi *providerIndex) createProviderVersion(ctx context.Context, version stri
 		// Currently the Terraform Registry returns the zh hash for all platforms,
 		// but not the h1 hash, so the h1 hash has to be calculated separately.
 		// We need to calculate the values for each platform and merge the results.
-		pv, err := buildProviderVersion(pi.address, version, platform, res)
+		pv, err := buildProviderVersionFromDownload(pi.address, version, platform, res)
 		if err != nil {
 			return nil, err
 		}
@@ -139,11 +178,87 @@ func (pi *providerIndex) createProviderVersion(ctx context.Context, version stri
 	return ret, nil
 }
 
-// newProviderDownloadRequest is a helper function for building the parameters for downloading provider.
+// fetchProviderPackageMetadata fetches the provider package metadata from the registry and returns an instance of the ProviderVersion.
+func (pi *providerIndex) fetchProviderPackageMetadata(ctx context.Context, version string, platform string) (*ProviderVersion, error) {
+	req, err := newProviderPackageMetadataRequest(pi.address, version, platform)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] providerIndex.fetchProviderPackageMetadata: %s, %s, %s", pi.address, version, platform)
+	res, err := pi.tfrapi.ProviderPackageMetadata(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	pv, err := buildProviderVersionFromPackageMetadata(pi.address, version, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return pv, nil
+}
+
+// newProviderPackageMetadataRequest is a helper function for building the parameters for fetching provider package metadata.
 // address is a provider address such as hashicorp/null.
 // version is a version number such as 3.2.1.
 // platform is a target platform name such as darwin_arm64.
-func newProviderDownloadRequest(address string, version string, platform string) (*ProviderDownloadRequest, error) {
+func newProviderPackageMetadataRequest(address string, version string, platform string) (*tfregistry.ProviderPackageMetadataRequest, error) {
+	pAddr, err := parseProviderAddress(address)
+	if err != nil {
+		return nil, err
+	}
+
+	os, arch, err := parseProviderPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	metadataReq := &tfregistry.ProviderPackageMetadataRequest{
+		Namespace: pAddr.Namespace,
+		Type:      pAddr.Type,
+		Version:   version,
+		OS:        os,
+		Arch:      arch,
+	}
+
+	return metadataReq, nil
+}
+
+// buildProviderVersion calculates hash values from the ProviderPackageMetadataResponse
+// and returns an instance of the ProviderVersion.
+// Note that while OpenTofu Registry responses include both h1 and zh hashes, Terraform Registry responses include only the zh hash.
+func buildProviderVersionFromPackageMetadata(address string, version string, res *tfregistry.ProviderPackageMetadataResponse) (*ProviderVersion, error) {
+	h1Hashes := make(map[string]string)
+	zhHashes := make(map[string]string)
+
+	for platform, pkg := range res.Packages {
+		for _, h := range pkg.Hashes {
+			if strings.HasPrefix(h, "h1:") {
+				h1Hashes[platform] = h
+			} else if strings.HasPrefix(h, "zh:") {
+				zhHashes[platform] = h
+			} else {
+				return nil, fmt.Errorf("unknown hash type: %s", h)
+			}
+		}
+	}
+
+	platforms := slices.Collect(maps.Keys(res.Packages))
+	pv := &ProviderVersion{
+		address:   address,
+		version:   version,
+		platforms: platforms,
+		h1Hashes:  h1Hashes,
+		zhHashes:  zhHashes,
+	}
+
+	return pv, nil
+}
+
+// parseProviderAddress parses a provider address and returns an instance of tfaddr.Provider.
+// The provider address is expected to be in the format of "namespace/type", such as "hashicorp/null".
+func parseProviderAddress(address string) (*tfaddr.Provider, error) {
 	// We parse an provider address by using the terraform-registry-address
 	// library to support fully qualified addresses such as
 	// registry.terraform.io/hashicorp/null in the future, but note that the
@@ -164,12 +279,36 @@ func newProviderDownloadRequest(address string, version string, platform string)
 		return nil, fmt.Errorf("failed to parse legacy provider aaddress: %s", address)
 	}
 
+	return &pAddr, nil
+}
+
+// parseProviderPlatform parses a platform name and returns the operating system and CPU architecture.
+// The platform name is expected to be in the format of "os_arch", such as "darwin_arm64".
+func parseProviderPlatform(platform string) (string, string, error) {
 	pf := strings.Split(platform, "_")
 	if len(pf) != 2 {
-		return nil, fmt.Errorf("failed to parse platform: %s", platform)
+		return "", "", fmt.Errorf("failed to parse platform: %s", platform)
 	}
+
 	os := pf[0]
 	arch := pf[1]
+	return os, arch, nil
+}
+
+// newProviderDownloadRequest is a helper function for building the parameters for downloading provider.
+// address is a provider address such as hashicorp/null.
+// version is a version number such as 3.2.1.
+// platform is a target platform name such as darwin_arm64.
+func newProviderDownloadRequest(address string, version string, platform string) (*ProviderDownloadRequest, error) {
+	pAddr, err := parseProviderAddress(address)
+	if err != nil {
+		return nil, err
+	}
+
+	os, arch, err := parseProviderPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &ProviderDownloadRequest{
 		Namespace: pAddr.Namespace,
@@ -182,9 +321,9 @@ func newProviderDownloadRequest(address string, version string, platform string)
 	return req, nil
 }
 
-// buildProviderVersion calculates hash values from the ProviderDownloadResponse
+// buildProviderVersionFromDownload calculates hash values from the ProviderDownloadResponse
 // and returns an instance of the ProviderVersion.
-func buildProviderVersion(address string, version string, platform string, res *ProviderDownloadResponse) (*ProviderVersion, error) {
+func buildProviderVersionFromDownload(address string, version string, platform string, res *ProviderDownloadResponse) (*ProviderVersion, error) {
 	h1Hashes := make(map[string]string)
 
 	h1, err := zipDataToH1Hash(res.zipData)

--- a/lock/index.go
+++ b/lock/index.go
@@ -123,13 +123,12 @@ func (pi *providerIndex) createProviderVersion(ctx context.Context, version stri
 			return nil, err
 		}
 
-		if len(pv.h1Hashes) != 0 && len(pv.zhHashes) != 0 {
-			// If both the h1 and zh hashes are available, we can skip downloading the provider binary.
-			log.Printf("[DEBUG] providerIndex.createProviderVersion: %s, %s. The registry returns both h1 and zh hashes. Skipping provider download.", pi.address, version)
-			return pv, nil
-		} else {
-			return nil, fmt.Errorf("failed to fetch provider package metadata for %s %s. The registry does not support h1 hashes. Please specify the platform on which the hash value should be calculated.", pi.address, version)
+		if len(pv.h1Hashes) == 0 {
+			return nil, fmt.Errorf("failed to fetch provider package metadata for %s %s. The registry does not support h1 hashes. Please specify the platform on which the hash value should be calculated", pi.address, version)
 		}
+		// If h1 hashes are available, we can skip downloading the provider binary.
+		log.Printf("[DEBUG] providerIndex.createProviderVersion: %s, %s. The registry returns both h1 and zh hashes. Skipping provider download.", pi.address, version)
+		return pv, nil
 	}
 
 	ret := newEmptyProviderVersion(pi.address, version)

--- a/lock/index.go
+++ b/lock/index.go
@@ -30,37 +30,27 @@ type index struct {
 	// The key is a provider address such as hashicorp/null.
 	providers map[string]*providerIndex
 
-	// tfrapi is an instance of tfregistry.API interface.
-	// It can be replaced for testing.
-	tfrapi tfregistry.API
-
 	// papi is a ProviderLockAPI interface implementation used for locking provider.
 	papi ProviderLockAPI
 }
 
 // NewIndexFromConfig returns a new instance of Index with the given registry config.
 func NewIndexFromConfig(config tfregistry.Config) (Index, error) {
-	tfrapi, err := tfregistry.NewClient(config)
-	if err != nil {
-		return nil, err
-	}
-
 	client, err := NewProviderLockClient(config)
 	if err != nil {
 		return nil, err
 	}
 
-	index := NewIndex(tfrapi, client)
+	index := NewIndex(client)
 
 	return index, nil
 }
 
-// NewIndex returns a new instance of Index with the given provider downloader API.
-func NewIndex(tfrapi tfregistry.API, papi ProviderLockAPI) Index {
+// NewIndex returns a new instance of Index with the given ProviderLockAPI.
+func NewIndex(papi ProviderLockAPI) Index {
 	providers := make(map[string]*providerIndex)
 	return &index{
 		providers: providers,
-		tfrapi:    tfrapi,
 		papi:      papi,
 	}
 }
@@ -71,7 +61,7 @@ func (i *index) GetOrCreateProviderVersion(ctx context.Context, address string, 
 	pi, ok := i.providers[address]
 	if !ok {
 		// cache miss
-		pi = newProviderIndex(address, i.tfrapi, i.papi)
+		pi = newProviderIndex(address, i.papi)
 		i.providers[address] = pi
 	}
 	// Delegate to ProviderIndex.
@@ -87,21 +77,16 @@ type providerIndex struct {
 	// The key is a version number such as 3.2.1.
 	versions map[string]*ProviderVersion
 
-	// tfrapi is an instance of tfregistry.API interface.
-	// It can be replaced for testing.
-	tfrapi tfregistry.API
-
 	// papi is a ProviderLockAPI interface implementation used for locking provider.
 	papi ProviderLockAPI
 }
 
 // newProviderIndex returns a new instance of providerIndex.
-func newProviderIndex(address string, tfrapi tfregistry.API, papi ProviderLockAPI) *providerIndex {
+func newProviderIndex(address string, papi ProviderLockAPI) *providerIndex {
 	versions := make(map[string]*ProviderVersion)
 	return &providerIndex{
 		address:  address,
 		versions: versions,
-		tfrapi:   tfrapi,
 		papi:     papi,
 	}
 }
@@ -186,7 +171,7 @@ func (pi *providerIndex) fetchProviderPackageMetadata(ctx context.Context, versi
 	}
 
 	log.Printf("[DEBUG] providerIndex.fetchProviderPackageMetadata: %s, %s, %s", pi.address, version, platform)
-	res, err := pi.tfrapi.ProviderPackageMetadata(ctx, req)
+	res, err := pi.papi.ProviderPackageMetadata(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +188,7 @@ func (pi *providerIndex) fetchProviderPackageMetadata(ctx context.Context, versi
 // address is a provider address such as hashicorp/null.
 // version is a version number such as 3.2.1.
 // platform is a target platform name such as darwin_arm64.
-func newProviderPackageMetadataRequest(address string, version string, platform string) (*tfregistry.ProviderPackageMetadataRequest, error) {
+func newProviderPackageMetadataRequest(address string, version string, platform string) (*ProviderPackageMetadataRequest, error) {
 	pAddr, err := parseProviderAddress(address)
 	if err != nil {
 		return nil, err
@@ -214,7 +199,7 @@ func newProviderPackageMetadataRequest(address string, version string, platform 
 		return nil, err
 	}
 
-	metadataReq := &tfregistry.ProviderPackageMetadataRequest{
+	metadataReq := &ProviderPackageMetadataRequest{
 		Namespace: pAddr.Namespace,
 		Type:      pAddr.Type,
 		Version:   version,
@@ -228,7 +213,7 @@ func newProviderPackageMetadataRequest(address string, version string, platform 
 // buildProviderVersion calculates hash values from the ProviderPackageMetadataResponse
 // and returns an instance of the ProviderVersion.
 // Note that while OpenTofu Registry responses include both h1 and zh hashes, Terraform Registry responses include only the zh hash.
-func buildProviderVersionFromPackageMetadata(address string, version string, res *tfregistry.ProviderPackageMetadataResponse) (*ProviderVersion, error) {
+func buildProviderVersionFromPackageMetadata(address string, version string, res *ProviderPackageMetadataResponse) (*ProviderVersion, error) {
 	h1Hashes := make(map[string]string)
 	zhHashes := make(map[string]string)
 

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -316,6 +317,7 @@ func TestBuildProviderVersionFromDownload(t *testing.T) {
 
 func TestProviderIndexFetchProviderPackageMetadata(t *testing.T) {
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
+	sort.Strings(allPlatforms)
 
 	cases := []struct {
 		desc     string
@@ -472,6 +474,7 @@ func TestNewProviderPackageMetadataRequest(t *testing.T) {
 
 func TestBuildProviderVersionFromPackageMetadata(t *testing.T) {
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
+	sort.Strings(allPlatforms)
 
 	cases := []struct {
 		desc    string

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
-// mockProviderDownloaderClient is a mock ProviderDownloaderAPI implementation.
-type mockProviderDownloaderClient struct {
+// mockProviderLockClient is a mock ProviderLockAPI implementation.
+type mockProviderLockClient struct {
 	called    int
 	responses []*ProviderDownloadResponse
 	errs      []error
 }
 
-var _ ProviderDownloaderAPI = (*mockProviderDownloaderClient)(nil)
+var _ ProviderLockAPI = (*mockProviderLockClient)(nil)
 
-func (c *mockProviderDownloaderClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) { // nolint revive unused-parameter
+func (c *mockProviderLockClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) { // nolint revive unused-parameter
 	res := c.responses[c.called]
 	err := c.errs[c.called]
 	c.called++
@@ -29,7 +29,7 @@ func (c *mockProviderDownloaderClient) ProviderDownload(ctx context.Context, req
 func TestIndexGetOrCreateProviderVersion(t *testing.T) {
 	targetPlatforms := []string{"darwin_arm64"}
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
-	client := &mockProviderDownloaderClient{}
+	client := &mockProviderLockClient{}
 	index := NewIndex(nil, client)
 
 	for _, address := range []string{"minamijoyo/dummy", "minamijoyo/null"} {
@@ -118,7 +118,7 @@ func TestProviderIndexGetOrCreateProviderVersion(t *testing.T) {
 			mockResponses = append(mockResponses, res...)
 			mockResponses = append(mockResponses, res...)
 			mockNoErrors := make([]error, len(tc.platforms)*2)
-			client := &mockProviderDownloaderClient{
+			client := &mockProviderLockClient{
 				responses: mockResponses,
 				errs:      mockNoErrors,
 			}

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -314,6 +314,162 @@ func TestBuildProviderVersionFromDownload(t *testing.T) {
 	}
 }
 
+func TestProviderIndexFetchProviderPackageMetadata(t *testing.T) {
+	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
+
+	cases := []struct {
+		desc     string
+		address  string
+		version  string
+		platform string
+		code     int
+		res      *tfregistry.ProviderPackageMetadataResponse
+		want     *ProviderVersion
+		ok       bool
+	}{
+		{
+			desc:     "simple",
+			address:  "minamijoyo/dummy",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			code:     200,
+			res:      newMockProviderPackageMetadataResponse(),
+			want: &ProviderVersion{
+				address:   "minamijoyo/dummy",
+				version:   "3.2.1",
+				platforms: allPlatforms,
+				h1Hashes: map[string]string{
+					"terraform-provider-dummy_3.2.1_darwin_arm64.zip":  "h1:3323G20HW9PA9ONrL6CdQCdCFe6y94kXeOTprq+Zu+w=",
+					"terraform-provider-dummy_3.2.1_darwin_amd64.zip":  "h1:63My0EuWIYHWVwWOxmxWwgrfx+58Tz+nTduelaCCAfs=",
+					"terraform-provider-dummy_3.2.1_linux_amd64.zip":   "h1:2zotrPRAjGZZMkjJGBGLnIbG+sqhQN30sbwqSDECQFQ=",
+					"terraform-provider-dummy_3.2.1_windows_amd64.zip": "h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
+				},
+				zhHashes: map[string]string{
+					"terraform-provider-dummy_3.2.1_darwin_arm64.zip":  "zh:5622a0fd03420ed1fa83a1a6e90b65fbe34bc74c251b3b47048f14217e93b086",
+					"terraform-provider-dummy_3.2.1_darwin_amd64.zip":  "zh:fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2",
+					"terraform-provider-dummy_3.2.1_linux_amd64.zip":   "zh:c5f0a44e3a3795cb3ee0abb0076097c738294c241f74c145dfb50f2b9fd71fd2",
+					"terraform-provider-dummy_3.2.1_windows_amd64.zip": "zh:8b75ff41191a7fe6c5d9129ed19a01eacde5a3797b48b738eefa21f5330c081e",
+				},
+			},
+			ok: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			client := &mockTFRegistryClient{
+				metadataRes: tc.res,
+				err:         nil,
+			}
+			pi := newProviderIndex(tc.address, client, nil)
+
+			got, err := pi.fetchProviderPackageMetadata(context.Background(), tc.version, tc.platform)
+
+			if tc.ok && err != nil {
+				t.Fatalf("failed to call fetchProviderPackageMetadata: err = %s", err)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to fail, but success: got = %s", spew.Sdump(got))
+			}
+
+			if diff := cmp.Diff(got, tc.want, cmp.AllowUnexported(ProviderVersion{})); diff != "" {
+				t.Errorf("got: %s, want = %s, diff = %s", spew.Sdump(got), spew.Sdump(tc.want), diff)
+			}
+		})
+	}
+}
+
+func TestNewProviderPackageMetadataRequest(t *testing.T) {
+	cases := []struct {
+		desc     string
+		address  string
+		version  string
+		platform string
+		want     *tfregistry.ProviderPackageMetadataRequest
+		ok       bool
+	}{
+		{
+			desc:     "simple",
+			address:  "minamijoyo/dummy",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			want: &tfregistry.ProviderPackageMetadataRequest{
+				Namespace: "minamijoyo",
+				Type:      "dummy",
+				Version:   "3.2.1",
+				OS:        "darwin",
+				Arch:      "arm64",
+			},
+			ok: true,
+		},
+		{
+			desc:     "fully qualified provider address",
+			address:  "registry.terraform.io/minamijoyo/dummy",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			want: &tfregistry.ProviderPackageMetadataRequest{
+				Namespace: "minamijoyo",
+				Type:      "dummy",
+				Version:   "3.2.1",
+				OS:        "darwin",
+				Arch:      "arm64",
+			},
+			ok: true,
+		},
+		{
+			desc:     "unknown provider namespace",
+			address:  "null",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			want:     nil,
+			ok:       false,
+		},
+		{
+			desc:     "legacy provider namespace",
+			address:  "-/null",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			want:     nil,
+			ok:       false,
+		},
+		{
+			desc:     "zero provider namespace",
+			address:  "",
+			version:  "3.2.1",
+			platform: "darwin_arm64",
+			want:     nil,
+			ok:       false,
+		},
+		{
+			desc:     "invalid platform",
+			address:  "minamijoyo/dummy",
+			version:  "3.2.1",
+			platform: "foo",
+			want:     nil,
+			ok:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := newProviderPackageMetadataRequest(tc.address, tc.version, tc.platform)
+
+			if tc.ok && err != nil {
+				t.Fatalf("failed to call newProviderDownloadRequest: err = %s", err)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to fail, but success: got = %s", spew.Sdump(got))
+			}
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("got: %s, want = %s, diff = %s", spew.Sdump(got), spew.Sdump(tc.want), diff)
+			}
+		})
+	}
+}
+
 func TestBuildProviderVersionFromPackageMetadata(t *testing.T) {
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
 
@@ -329,38 +485,7 @@ func TestBuildProviderVersionFromPackageMetadata(t *testing.T) {
 			desc:    "simple",
 			address: "minamijoyo/dummy",
 			version: "3.2.1",
-			res: &tfregistry.ProviderPackageMetadataResponse{
-				Filename:    "terraform-provider-dummy_3.2.1_darwin_arm64.zip",
-				DownloadURL: "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip",
-				SHASum:      "",
-				SHASumsURL:  "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_SHA256SUMS",
-				Packages: map[string]tfregistry.Package{
-					"darwin_arm64": {
-						Hashes: []string{
-							"zh:5622a0fd03420ed1fa83a1a6e90b65fbe34bc74c251b3b47048f14217e93b086",
-							"h1:3323G20HW9PA9ONrL6CdQCdCFe6y94kXeOTprq+Zu+w=",
-						},
-					},
-					"darwin_amd64": {
-						Hashes: []string{
-							"zh:fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2",
-							"h1:63My0EuWIYHWVwWOxmxWwgrfx+58Tz+nTduelaCCAfs=",
-						},
-					},
-					"linux_amd64": {
-						Hashes: []string{
-							"zh:c5f0a44e3a3795cb3ee0abb0076097c738294c241f74c145dfb50f2b9fd71fd2",
-							"h1:2zotrPRAjGZZMkjJGBGLnIbG+sqhQN30sbwqSDECQFQ=",
-						},
-					},
-					"windows_amd64": {
-						Hashes: []string{
-							"zh:8b75ff41191a7fe6c5d9129ed19a01eacde5a3797b48b738eefa21f5330c081e",
-							"h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
-						},
-					},
-				},
-			},
+			res:     newMockProviderPackageMetadataResponse(),
 			want: &ProviderVersion{
 				address:   "minamijoyo/dummy",
 				version:   "3.2.1",

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -19,11 +19,11 @@ type mockProviderLockClient struct {
 
 var _ ProviderLockAPI = (*mockProviderLockClient)(nil)
 
-func (c *mockProviderLockClient) ProviderPackageMetadata(ctx context.Context, req *ProviderPackageMetadataRequest) (*ProviderPackageMetadataResponse, error) {
+func (c *mockProviderLockClient) ProviderPackageMetadata(_ context.Context, _ *ProviderPackageMetadataRequest) (*ProviderPackageMetadataResponse, error) {
 	return c.metadataRes, nil
 }
 
-func (c *mockProviderLockClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) { // nolint revive unused-parameter
+func (c *mockProviderLockClient) ProviderDownload(_ context.Context, _ *ProviderDownloadRequest) (*ProviderDownloadResponse, error) {
 	res := c.responses[c.called]
 	err := c.errs[c.called]
 	c.called++

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -7,17 +7,21 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
 // mockProviderLockClient is a mock ProviderLockAPI implementation.
 type mockProviderLockClient struct {
-	called    int
-	responses []*ProviderDownloadResponse
-	errs      []error
+	called      int
+	metadataRes *ProviderPackageMetadataResponse
+	responses   []*ProviderDownloadResponse
+	errs        []error
 }
 
 var _ ProviderLockAPI = (*mockProviderLockClient)(nil)
+
+func (c *mockProviderLockClient) ProviderPackageMetadata(ctx context.Context, req *ProviderPackageMetadataRequest) (*ProviderPackageMetadataResponse, error) {
+	return c.metadataRes, nil
+}
 
 func (c *mockProviderLockClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) { // nolint revive unused-parameter
 	res := c.responses[c.called]
@@ -30,7 +34,7 @@ func TestIndexGetOrCreateProviderVersion(t *testing.T) {
 	targetPlatforms := []string{"darwin_arm64"}
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
 	client := &mockProviderLockClient{}
-	index := NewIndex(nil, client)
+	index := NewIndex(client)
 
 	for _, address := range []string{"minamijoyo/dummy", "minamijoyo/null"} {
 		for _, version := range []string{"3.2.1", "3.2.2"} {
@@ -122,7 +126,7 @@ func TestProviderIndexGetOrCreateProviderVersion(t *testing.T) {
 				responses: mockResponses,
 				errs:      mockNoErrors,
 			}
-			pi := newProviderIndex(tc.address, nil, client)
+			pi := newProviderIndex(tc.address, client)
 
 			// 1st call
 			got, err := pi.getOrCreateProviderVersion(context.Background(), tc.version, tc.platforms)
@@ -325,7 +329,6 @@ func TestProviderIndexFetchProviderPackageMetadata(t *testing.T) {
 		version  string
 		platform string
 		code     int
-		res      *tfregistry.ProviderPackageMetadataResponse
 		want     *ProviderVersion
 		ok       bool
 	}{
@@ -335,7 +338,6 @@ func TestProviderIndexFetchProviderPackageMetadata(t *testing.T) {
 			version:  "3.2.1",
 			platform: "darwin_arm64",
 			code:     200,
-			res:      newMockProviderPackageMetadataResponse(),
 			want: &ProviderVersion{
 				address:   "minamijoyo/dummy",
 				version:   "3.2.1",
@@ -359,11 +361,11 @@ func TestProviderIndexFetchProviderPackageMetadata(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			client := &mockTFRegistryClient{
-				metadataRes: tc.res,
-				err:         nil,
+			res := newMockProviderPackageMetadataResponse()
+			client := &mockProviderLockClient{
+				metadataRes: res,
 			}
-			pi := newProviderIndex(tc.address, client, nil)
+			pi := newProviderIndex(tc.address, client)
 
 			got, err := pi.fetchProviderPackageMetadata(context.Background(), tc.version, tc.platform)
 
@@ -388,7 +390,7 @@ func TestNewProviderPackageMetadataRequest(t *testing.T) {
 		address  string
 		version  string
 		platform string
-		want     *tfregistry.ProviderPackageMetadataRequest
+		want     *ProviderPackageMetadataRequest
 		ok       bool
 	}{
 		{
@@ -396,7 +398,7 @@ func TestNewProviderPackageMetadataRequest(t *testing.T) {
 			address:  "minamijoyo/dummy",
 			version:  "3.2.1",
 			platform: "darwin_arm64",
-			want: &tfregistry.ProviderPackageMetadataRequest{
+			want: &ProviderPackageMetadataRequest{
 				Namespace: "minamijoyo",
 				Type:      "dummy",
 				Version:   "3.2.1",
@@ -410,7 +412,7 @@ func TestNewProviderPackageMetadataRequest(t *testing.T) {
 			address:  "registry.terraform.io/minamijoyo/dummy",
 			version:  "3.2.1",
 			platform: "darwin_arm64",
-			want: &tfregistry.ProviderPackageMetadataRequest{
+			want: &ProviderPackageMetadataRequest{
 				Namespace: "minamijoyo",
 				Type:      "dummy",
 				Version:   "3.2.1",
@@ -480,7 +482,7 @@ func TestBuildProviderVersionFromPackageMetadata(t *testing.T) {
 		desc    string
 		address string
 		version string
-		res     *tfregistry.ProviderPackageMetadataResponse
+		res     *ProviderPackageMetadataResponse
 		want    *ProviderVersion
 		ok      bool
 	}{

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
 // mockProviderDownloaderClient is a mock ProviderDownloaderAPI implementation.
@@ -299,7 +300,94 @@ func TestBuildProviderVersionFromDownload(t *testing.T) {
 			got, err := buildProviderVersionFromDownload(tc.address, tc.version, tc.platform, res)
 
 			if tc.ok && err != nil {
-				t.Fatalf("failed to call buildProviderVersion: err = %s", err)
+				t.Fatalf("failed to call buildProviderVersionFromDownload: err = %s", err)
+			}
+
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to fail, but success: got = %s", spew.Sdump(got))
+			}
+
+			if diff := cmp.Diff(got, tc.want, cmp.AllowUnexported(ProviderVersion{})); diff != "" {
+				t.Errorf("got: %s, want = %s, diff = %s", spew.Sdump(got), spew.Sdump(tc.want), diff)
+			}
+		})
+	}
+}
+
+func TestBuildProviderVersionFromPackageMetadata(t *testing.T) {
+	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
+
+	cases := []struct {
+		desc    string
+		address string
+		version string
+		res     *tfregistry.ProviderPackageMetadataResponse
+		want    *ProviderVersion
+		ok      bool
+	}{
+		{
+			desc:    "simple",
+			address: "minamijoyo/dummy",
+			version: "3.2.1",
+			res: &tfregistry.ProviderPackageMetadataResponse{
+				Filename:    "terraform-provider-dummy_3.2.1_darwin_arm64.zip",
+				DownloadURL: "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip",
+				SHASum:      "",
+				SHASumsURL:  "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_SHA256SUMS",
+				Packages: map[string]tfregistry.Package{
+					"darwin_arm64": {
+						Hashes: []string{
+							"zh:5622a0fd03420ed1fa83a1a6e90b65fbe34bc74c251b3b47048f14217e93b086",
+							"h1:3323G20HW9PA9ONrL6CdQCdCFe6y94kXeOTprq+Zu+w=",
+						},
+					},
+					"darwin_amd64": {
+						Hashes: []string{
+							"zh:fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2",
+							"h1:63My0EuWIYHWVwWOxmxWwgrfx+58Tz+nTduelaCCAfs=",
+						},
+					},
+					"linux_amd64": {
+						Hashes: []string{
+							"zh:c5f0a44e3a3795cb3ee0abb0076097c738294c241f74c145dfb50f2b9fd71fd2",
+							"h1:2zotrPRAjGZZMkjJGBGLnIbG+sqhQN30sbwqSDECQFQ=",
+						},
+					},
+					"windows_amd64": {
+						Hashes: []string{
+							"zh:8b75ff41191a7fe6c5d9129ed19a01eacde5a3797b48b738eefa21f5330c081e",
+							"h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
+						},
+					},
+				},
+			},
+			want: &ProviderVersion{
+				address:   "minamijoyo/dummy",
+				version:   "3.2.1",
+				platforms: allPlatforms,
+				h1Hashes: map[string]string{
+					"terraform-provider-dummy_3.2.1_darwin_arm64.zip":  "h1:3323G20HW9PA9ONrL6CdQCdCFe6y94kXeOTprq+Zu+w=",
+					"terraform-provider-dummy_3.2.1_darwin_amd64.zip":  "h1:63My0EuWIYHWVwWOxmxWwgrfx+58Tz+nTduelaCCAfs=",
+					"terraform-provider-dummy_3.2.1_linux_amd64.zip":   "h1:2zotrPRAjGZZMkjJGBGLnIbG+sqhQN30sbwqSDECQFQ=",
+					"terraform-provider-dummy_3.2.1_windows_amd64.zip": "h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
+				},
+				zhHashes: map[string]string{
+					"terraform-provider-dummy_3.2.1_darwin_arm64.zip":  "zh:5622a0fd03420ed1fa83a1a6e90b65fbe34bc74c251b3b47048f14217e93b086",
+					"terraform-provider-dummy_3.2.1_darwin_amd64.zip":  "zh:fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2",
+					"terraform-provider-dummy_3.2.1_linux_amd64.zip":   "zh:c5f0a44e3a3795cb3ee0abb0076097c738294c241f74c145dfb50f2b9fd71fd2",
+					"terraform-provider-dummy_3.2.1_windows_amd64.zip": "zh:8b75ff41191a7fe6c5d9129ed19a01eacde5a3797b48b738eefa21f5330c081e",
+				},
+			},
+			ok: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := buildProviderVersionFromPackageMetadata(tc.address, tc.version, tc.res)
+
+			if tc.ok && err != nil {
+				t.Fatalf("failed to call buildProviderVersionFromPackageMetadata: err = %s", err)
 			}
 
 			if !tc.ok && err == nil {

--- a/lock/index_test.go
+++ b/lock/index_test.go
@@ -28,7 +28,7 @@ func TestIndexGetOrCreateProviderVersion(t *testing.T) {
 	targetPlatforms := []string{"darwin_arm64"}
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
 	client := &mockProviderDownloaderClient{}
-	index := NewIndex(client)
+	index := NewIndex(nil, client)
 
 	for _, address := range []string{"minamijoyo/dummy", "minamijoyo/null"} {
 		for _, version := range []string{"3.2.1", "3.2.2"} {
@@ -120,7 +120,7 @@ func TestProviderIndexGetOrCreateProviderVersion(t *testing.T) {
 				responses: mockResponses,
 				errs:      mockNoErrors,
 			}
-			pi := newProviderIndex(tc.address, client)
+			pi := newProviderIndex(tc.address, nil, client)
 
 			// 1st call
 			got, err := pi.getOrCreateProviderVersion(context.Background(), tc.version, tc.platforms)
@@ -255,7 +255,7 @@ func TestNewProviderDownloadRequest(t *testing.T) {
 	}
 }
 
-func TestBuildProviderVersion(t *testing.T) {
+func TestBuildProviderVersionFromDownload(t *testing.T) {
 	allPlatforms := []string{"darwin_arm64", "darwin_amd64", "linux_amd64", "windows_amd64"}
 
 	cases := []struct {
@@ -296,7 +296,7 @@ func TestBuildProviderVersion(t *testing.T) {
 				t.Fatalf("failed to create mockResponse: err = %s", err)
 			}
 
-			got, err := buildProviderVersion(tc.address, tc.version, tc.platform, res)
+			got, err := buildProviderVersionFromDownload(tc.address, tc.version, tc.platform, res)
 
 			if tc.ok && err != nil {
 				t.Fatalf("failed to call buildProviderVersion: err = %s", err)

--- a/lock/mock.go
+++ b/lock/mock.go
@@ -147,12 +147,13 @@ func newMockProviderDownloadResponses(address string, version string, targetPlat
 func NewMockIndex(pvs []*ProviderVersion) Index {
 	i := &index{
 		providers: make(map[string]*providerIndex),
+		tfrapi:    nil,
 		papi:      nil,
 	}
 	for _, pv := range pvs {
 		pi, ok := i.providers[pv.address]
 		if !ok {
-			pi = newProviderIndex(pv.address, i.papi)
+			pi = newProviderIndex(pv.address, i.tfrapi, i.papi)
 			i.providers[pv.address] = pi
 		}
 		pi.versions[pv.version] = pv

--- a/lock/mock.go
+++ b/lock/mock.go
@@ -44,9 +44,9 @@ func newMockServer() (*http.ServeMux, *url.URL) {
 }
 
 // newTestClient returns a new client for testing.
-func newTestClient(mockServerURL *url.URL, config tfregistry.Config) *ProviderDownloaderClient {
+func newTestClient(mockServerURL *url.URL, config tfregistry.Config) *ProviderLockClient {
 	config.BaseURL = mockServerURL.String()
-	c, _ := NewProviderDownloaderClient(config)
+	c, _ := NewProviderLockClient(config)
 	return c
 }
 

--- a/lock/mock.go
+++ b/lock/mock.go
@@ -129,6 +129,43 @@ func newMockProviderDownloadResponse(address string, version string, targetPlatf
 	}, nil
 }
 
+func newMockProviderPackageMetadataResponse() *tfregistry.ProviderPackageMetadataResponse {
+	res := &tfregistry.ProviderPackageMetadataResponse{
+		Filename:    "terraform-provider-dummy_3.2.1_darwin_arm64.zip",
+		DownloadURL: "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip",
+		SHASum:      "",
+		SHASumsURL:  "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_SHA256SUMS",
+		Packages: map[string]tfregistry.Package{
+			"darwin_arm64": {
+				Hashes: []string{
+					"zh:5622a0fd03420ed1fa83a1a6e90b65fbe34bc74c251b3b47048f14217e93b086",
+					"h1:3323G20HW9PA9ONrL6CdQCdCFe6y94kXeOTprq+Zu+w=",
+				},
+			},
+			"darwin_amd64": {
+				Hashes: []string{
+					"zh:fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2",
+					"h1:63My0EuWIYHWVwWOxmxWwgrfx+58Tz+nTduelaCCAfs=",
+				},
+			},
+			"linux_amd64": {
+				Hashes: []string{
+					"zh:c5f0a44e3a3795cb3ee0abb0076097c738294c241f74c145dfb50f2b9fd71fd2",
+					"h1:2zotrPRAjGZZMkjJGBGLnIbG+sqhQN30sbwqSDECQFQ=",
+				},
+			},
+			"windows_amd64": {
+				Hashes: []string{
+					"zh:8b75ff41191a7fe6c5d9129ed19a01eacde5a3797b48b738eefa21f5330c081e",
+					"h1:PwmSfP1Tb8io64qqCx9AExzIqnHiZ/ER2l8qVhEEKdw=",
+				},
+			},
+		},
+	}
+
+	return res
+}
+
 // newMockProviderDownloadResponses returns a new list of ProviderDownloadResponse for testing.
 func newMockProviderDownloadResponses(address string, version string, targetPlatforms []string, allPlatforms []string) ([]*ProviderDownloadResponse, error) {
 	responses := []*ProviderDownloadResponse{}

--- a/lock/mock.go
+++ b/lock/mock.go
@@ -129,8 +129,8 @@ func newMockProviderDownloadResponse(address string, version string, targetPlatf
 	}, nil
 }
 
-func newMockProviderPackageMetadataResponse() *tfregistry.ProviderPackageMetadataResponse {
-	res := &tfregistry.ProviderPackageMetadataResponse{
+func newMockProviderPackageMetadataResponse() *ProviderPackageMetadataResponse {
+	res := &ProviderPackageMetadataResponse{
 		Filename:    "terraform-provider-dummy_3.2.1_darwin_arm64.zip",
 		DownloadURL: "https://github.com/opentofu/terraform-provider-dummy/releases/download/v3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip",
 		SHASum:      "",
@@ -184,13 +184,12 @@ func newMockProviderDownloadResponses(address string, version string, targetPlat
 func NewMockIndex(pvs []*ProviderVersion) Index {
 	i := &index{
 		providers: make(map[string]*providerIndex),
-		tfrapi:    nil,
 		papi:      nil,
 	}
 	for _, pv := range pvs {
 		pi, ok := i.providers[pv.address]
 		if !ok {
-			pi = newProviderIndex(pv.address, i.tfrapi, i.papi)
+			pi = newProviderIndex(pv.address, i.papi)
 			i.providers[pv.address] = pi
 		}
 		pi.versions[pv.version] = pv

--- a/lock/provider_lock.go
+++ b/lock/provider_lock.go
@@ -13,28 +13,28 @@ import (
 	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
-// PackageDownloaderAPI is an interface for downloading provider package.
+// ProviderLockAPI is an interface for locking provider package.
 // Provider packages are downloaded from the HashiCorp release server,
 // GitHub release page or somewhere else.
 // Therefore we distinct this API from the Terraform Registry API.
 // The API specification is not documented.
-type ProviderDownloaderAPI interface {
+type ProviderLockAPI interface {
 	// ProviderDownload downloads a provider package.
 	ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error)
 }
 
-// ProviderDownloaderClient implements the ProviderDownloaderAPI interface
-type ProviderDownloaderClient struct {
+// ProviderLockClient implements the ProviderLockAPI interface
+type ProviderLockClient struct {
 	// api is an instance of tfregistry.API interface.
 	// It can be replaced for testing.
 	api tfregistry.API
 
-	// httpClient is a http client which communicates with the ProviderDownloaderAPI.
+	// httpClient is a http client which communicates with the ProviderLockAPI.
 	httpClient *http.Client
 }
 
-// NewProviderDownloaderClient is a factory method which returns a ProviderDownloaderClient instance.
-func NewProviderDownloaderClient(config tfregistry.Config) (*ProviderDownloaderClient, error) {
+// NewProviderLockClient is a factory method which returns a ProviderLockClient instance.
+func NewProviderLockClient(config tfregistry.Config) (*ProviderLockClient, error) {
 	api, err := tfregistry.NewClient(config)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func NewProviderDownloaderClient(config tfregistry.Config) (*ProviderDownloaderC
 		httpClient = &http.Client{}
 	}
 
-	return &ProviderDownloaderClient{
+	return &ProviderLockClient{
 		api:        api,
 		httpClient: httpClient,
 	}, nil
@@ -78,7 +78,7 @@ type ProviderDownloadResponse struct {
 }
 
 // ProviderDownload downloads a provider package.
-func (c *ProviderDownloaderClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) {
+func (c *ProviderLockClient) ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error) {
 	metadataReq := &tfregistry.ProviderPackageMetadataRequest{
 		Namespace: req.Namespace,
 		Type:      req.Type,
@@ -124,13 +124,13 @@ func (c *ProviderDownloaderClient) ProviderDownload(ctx context.Context, req *Pr
 }
 
 // download is a helper function that downloads contents from a given url.
-func (c *ProviderDownloaderClient) download(ctx context.Context, url string) ([]byte, error) {
+func (c *ProviderLockClient) download(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build http request: err = %s, url = %s", err, url)
 	}
 
-	log.Printf("[DEBUG] ProviderDownloaderClient.download: GET %s", url)
+	log.Printf("[DEBUG] ProviderLockClient.download: GET %s", url)
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request: err = %s, url = %s", err, url)

--- a/lock/provider_lock.go
+++ b/lock/provider_lock.go
@@ -19,6 +19,9 @@ import (
 // Therefore we distinct this API from the Terraform Registry API.
 // The API specification is not documented.
 type ProviderLockAPI interface {
+	// ProviderPackageMetadata returns a package metadata of a provider.
+	ProviderPackageMetadata(ctx context.Context, req *ProviderPackageMetadataRequest) (*ProviderPackageMetadataResponse, error)
+
 	// ProviderDownload downloads a provider package.
 	ProviderDownload(ctx context.Context, req *ProviderDownloadRequest) (*ProviderDownloadResponse, error)
 }
@@ -49,6 +52,20 @@ func NewProviderLockClient(config tfregistry.Config) (*ProviderLockClient, error
 		api:        api,
 		httpClient: httpClient,
 	}, nil
+}
+
+type ProviderPackageMetadataRequest tfregistry.ProviderPackageMetadataRequest
+type ProviderPackageMetadataResponse tfregistry.ProviderPackageMetadataResponse
+
+// ProviderPackageMetadata returns a package metadata of a provider.
+func (c *ProviderLockClient) ProviderPackageMetadata(ctx context.Context, req *ProviderPackageMetadataRequest) (*ProviderPackageMetadataResponse, error) {
+	tfrReq := (*tfregistry.ProviderPackageMetadataRequest)(req)
+	tfrRes, err := c.api.ProviderPackageMetadata(ctx, tfrReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*ProviderPackageMetadataResponse)(tfrRes), nil
 }
 
 // ProviderDownloadRequest is a request type for ProviderDownload.

--- a/lock/provider_lock_test.go
+++ b/lock/provider_lock_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/minamijoyo/tfupdate/tfregistry"
 )
 
-func TestProviderDownloaderClientProviderDownload(t *testing.T) {
+func TestProviderLockClientProviderDownload(t *testing.T) {
 	downloadPath := "/terraform-provider-dummy/3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip"
 	shaSumsPath := "/terraform-provider-dummy/3.2.1/terraform-provider-dummy_3.2.1_SHA256SUMS"
 
@@ -118,7 +118,7 @@ fc5bbdd0a1bd6715b9afddf3aba6acc494425d77015c19579b9a9fa950e532b2  terraform-prov
 	}
 }
 
-func TestProviderDownloaderClientDownload(t *testing.T) {
+func TestProviderLockClientDownload(t *testing.T) {
 	subPath := "/terraform-provider-dummy/3.2.1/terraform-provider-dummy_3.2.1_darwin_arm64.zip"
 	cases := []struct {
 		desc    string

--- a/tfregistry/provider_package_metadata.go
+++ b/tfregistry/provider_package_metadata.go
@@ -32,6 +32,16 @@ type ProviderPackageMetadataResponse struct {
 	SHASum string `json:"shasum"`
 	// (required): a URL from which Terraform can retrieve a text document recording expected SHA256 checksums for this package and possibly other packages for the same provider version on other platforms.
 	SHASumsURL string `json:"shasums_url"`
+	// (optional): a map of provider package metadata for all platforms. The keys are platform names such as darwin_arm64, and the values are metadata for each platform.
+	// To skip hash value calculation for the lock file, package information for platforms other than the platform specified in the request is also returned.
+	// This field is only returned by OpenTofu Registry and not returned by Terraform Registry.
+	Packages map[string]Package `json:"packages"`
+}
+
+// Package represents a provider package metadata for a specific platform. This includes pre-calculated hash values on the Registry side.
+type Package struct {
+	// The list of hash values for zh and h1 schemes.
+	Hashes []string `json:"hashes"`
 }
 
 // ProviderPackageMetadata returns a package metadata of a provider.

--- a/tfregistry/provider_package_metadata_test.go
+++ b/tfregistry/provider_package_metadata_test.go
@@ -120,6 +120,87 @@ func TestProviderPackageMetadata(t *testing.T) {
 			res:  "",
 			want: nil,
 		},
+		{
+			desc: "with hashes",
+			req: &ProviderPackageMetadataRequest{
+				Namespace: "hashicorp",
+				Type:      "null",
+				Version:   "3.2.1",
+				OS:        "darwin",
+				Arch:      "arm64",
+			},
+			ok:   true,
+			code: 200,
+			res:  mockProviderPackageMetadataResponseWithHashes,
+			want: &ProviderPackageMetadataResponse{
+				Filename:    "terraform-provider-null_3.2.1_darwin_arm64.zip",
+				DownloadURL: "https://github.com/opentofu/terraform-provider-null/releases/download/v3.2.1/terraform-provider-null_3.2.1_darwin_arm64.zip",
+				SHASum:      "5ce03460813954cbebc9f9ad5befbe364d9dc67acb08869f67c1aa634fbf6d6c",
+				SHASumsURL:  "https://github.com/opentofu/terraform-provider-null/releases/download/v3.2.1/terraform-provider-null_3.2.1_SHA256SUMS",
+				Packages: map[string]Package{
+					"darwin_amd64": {
+						Hashes: []string{
+							"zh:e25265d4e87821d18dc9653a0ce01978a1ae5d363bc01dd273454db1aa0309c7",
+							"h1:BdIx478D4wpFgFeaS+5Bdve1HIlt3Yhsr5hAbUs2rRg=",
+						},
+					},
+					"darwin_arm64": {
+						Hashes: []string{
+							"zh:5ce03460813954cbebc9f9ad5befbe364d9dc67acb08869f67c1aa634fbf6d6c",
+							"h1:+JAon/4CyriC/c7c77NjJalKrKx6gwwQ7L7rVABWMtA=",
+						},
+					},
+					"linux_386": {
+						Hashes: []string{
+							"zh:c38c9a295cfae9fb6372523c34b9466cd439d5e2c909b56a788960d387c24320",
+							"h1:Oio8EVe+5LQF7cd7IYcIrXkyKy8nCrBF/X8DQUAgayQ=",
+						},
+					},
+					"linux_amd64": {
+						Hashes: []string{
+							"zh:40335019c11e5bdb3780301da5197cbc756b4b5ac3d699c52583f1d34e963176",
+							"h1:uQv2oPjJv+ue8bPrVp+So2hHd90UTssnCNajTW554Cw=",
+						},
+					},
+					"linux_arm": {
+						Hashes: []string{
+							"zh:42356e687656fc8ec1f230f786f830f344e64419552ec483e2bc79bd4b7cf1e8",
+							"h1:+s8zqab9SoQhfWDJVRtv9b2pJRyQlZu88NHK0X4bODQ=",
+						},
+					},
+					"linux_arm64": {
+						Hashes: []string{
+							"zh:91a76f371815a130735c8fcb6196804d878aebcc67b4c3b73571d2063336ffd8",
+							"h1:9WdPl8ujc45POfiiCzcX60bljY744neqTGlK24VMhgk=",
+						},
+					},
+					"windows_386": {
+						Hashes: []string{
+							"zh:658ea3e3e7ecc964bdbd08ecde63f3d79f298bab9922b29a6526ba941a4d403a",
+							"h1:K7QNZz/LCsVhvHLA8orqjfVr+qYh4QAPhMi+n9Es6js=",
+						},
+					},
+					"windows_amd64": {
+						Hashes: []string{
+							"zh:80fd03335f793dc54302dd53da98c91fd94f182bcacf13457bed1a99ecffbc1a",
+							"h1:uvf7c5e8N7A0k9dqF2pLbbbPTAHIwUoM885CHCS717E=",
+						},
+					},
+					"windows_arm": {
+						Hashes: []string{
+							"zh:c146fc0291b7f6284fe4d54ce6aaece6957e9acc93fc572dd505dfd8bcad3e6c",
+							"h1:8sG3Tdnsk1STHIKaFORkb9EKaR6eNkzX1MCqWZLo6uY=",
+						},
+					},
+					"windows_arm64": {
+						Hashes: []string{
+							"zh:68c06703bc57f9c882bfedda6f3047775f0d367093d00efb040800c798b8a613",
+							"h1:ckcDeFlUdHEPosRUSxqyCzVdZLh9mrM4ebhygf6c3SA=",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -170,6 +251,100 @@ const mockProviderPackageMetadataResponse = `{
         "source_url": "https://www.hashicorp.com/security.html"
       }
     ]
+  }
+}
+`
+
+const mockProviderPackageMetadataResponseWithHashes = `{
+  "protocols": [
+    "5.0"
+  ],
+  "os": "darwin",
+  "arch": "arm64",
+  "filename": "terraform-provider-null_3.2.1_darwin_arm64.zip",
+  "download_url": "https://github.com/opentofu/terraform-provider-null/releases/download/v3.2.1/terraform-provider-null_3.2.1_darwin_arm64.zip",
+  "shasums_url": "https://github.com/opentofu/terraform-provider-null/releases/download/v3.2.1/terraform-provider-null_3.2.1_SHA256SUMS",
+  "shasums_signature_url": "https://github.com/opentofu/terraform-provider-null/releases/download/v3.2.1/terraform-provider-null_3.2.1_SHA256SUMS.sig",
+  "shasum": "5ce03460813954cbebc9f9ad5befbe364d9dc67acb08869f67c1aa634fbf6d6c",
+  "signing_keys": {
+    "gpg_public_keys": [
+      {
+        "ascii_armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nxsFNBGVUyIwBEADPg6jUJm5liMTiDndyprnwXQ23GdyQm/kW9MFOhYDRksmmbsz0\nDCfqntFpuoKxPXzA+JTrZlWZONtU+leZjIOlAVZiz0rwz5EJq7uIrkueWtUk6AYk\nBLN+zMtbui0z3HCPVNnR5BlVNyXQeW3jlrQtzuKevjZWzI0gbQGgEKNpj+lfyRFu\n6q3u/T0o3p/6bOOlQHwCMtnFlWpjr6f/J2EdUVO/6NYHQzImPj4LINXF/+eqo7v6\nsvFtaVTtREG2V2V7We7bu/cJ+NgJYH7ro7UhB1RQH2k09NdpSCt9F60PVERnORpx\nGBkM/VKZzgMSzRvdpxUWwrLxfAxinu5ddbBm3y0bzaU80OT3i1qrWIqW73fmdGHQ\n71gbJxRrroyLMWehjcJ/9WJDxkHqsfPKqBifYsp6/J9npczDfSU+zYBVGpR73a4E\ndbeIRWqwbH0LWhlbi1IM5aFDaZMFNkY+AWyP+OHn8Kehu6DOIh1AVM7v7vLxaX9h\nt1jVJbswjvPFYquv1DvUdc7VP2QHz3xctQS1GZJQ1ekcgTv9rRYXUOOwknInjtkM\n9kQDtyBkVLcEc8ha3Cfh6PJscIP5VHwaNMgAPr9tsl3xqdz56l5UPjFSFuel98jS\nBqn83VrT0uKwM0PnDVHd/7q8+Dg1EtOggMwZ830KORFNdjfv6ydsBvl7fwARAQAB\nzUpPcGVuVG9mdSAoVGhpcyBrZXkgaXMgdXNlZCB0byBzaWduIG9wZW50b2Z1IHBy\nb3ZpZGVycykgPGNvcmVAb3BlbnRvZnUub3JnPsLBjAQTAQgAQQUCZVTIjAkQDArz\nE+X9n4AWIQTj5uQ9hMuFLq2wBR0MCvMT5f2fgAIbAwIeAQIZAQMLCQcCFQgDFgAC\nBScJAgcCAABwAg/1HZnTvPHZDWf5OluYOaQ7ADX/oyjUO85VNUmKhmBZkLr5mTqr\nLO72k9fg+101hbggbhtK431z3Ca6ZqDAG/3DBi0BC1ag0rw83TEApkPGYnfX1DWS\n1ZvyH1PkV0aqCkXAtMrte2PlUiieaKAsiYOIXqfZwszd07gch14wxMOw1B6Au/Xz\nNrv2omnWSgGIyR6WOsG4QQ8R5AMVz3K8Ftzl6520wBgtr3osA3uM/xconnGVukMn\n9NLQqKx5oeaJwONZpyZL5bg2ke9MVZM2+bG30UGZKoxrzOtQ//OTOYlhPCqm1ffR\nhYrUytwsWzDnJvXJF1QhnDu8whP3tSrcHyKxYZ9xUNzeu2AmjYfvkKHSdK2DFmOf\nDafaRs3c1VYnC7J7aRi6kVF/t+vWeOEVpPylyK7vSbPFc6XVoQrsE07hbN/BjWjm\ns8voK5U6oJRgEugXtSQKFypfOq8R99nXwbMHdhqY8aGyOCj++cuvRCUBDZAQqPEW\nAuD0X7+9Trnfin47MK+n18wsTAL4w6PJhtCrwK4e0cVuQ5u4M/PMid5W6hEA27PX\nx506Jpe8iRmcIP/cCR6pvhgOUMC36bIkAqZ5dJ545kDQju0lf8gLdVIQpig45udn\nZM2KgyApGqhsS7yCUrbLDrtNmQ31TSYdKc8IU+/jXkfy2RYbZ+wNgfloKM7BTQRl\nVMiMARAAwRZUyMIc5TNbcFg3WGKxhaNC9hDZ4zBfXlb5jONzZOx3rDi2lD4UQOH+\nNpG7CF98co//kryS/4AsDdp2jzhh+VMgyx6KJIhSkBP6kqhriy9eWRmgfrnLbUf4\n6kkTkzLVkjYnMNeyHt+mi9I7EKtsDuF/EvjlwF5E81+DEOteCO/un/Qt1q3e1Slf\nvTpLkPvr1FiQ3VqzaBeBBI3MAMb/ycwL6hQE1l4Lg34T43Zu+9zkE1uzvjeNIlIW\nucjB4q1htEjJl2CLAv+8cGHdmCcV2ZO3WM8M9Omq1CE7jhak4NE/YuGylJYCBd+B\nS7tuDPDu6+o4Nx+axxcwMvgyfr07FteEr1Lopaw2ci8b/xzQie/gkI0CByQMwD5V\ngnJpiMBnjP4d6UF6HEVldCQ7a3T1T80bKj5JjtFbR9P85Qntuheqn3Pge89YexMc\nE/00VA3blrj+GeYpO9ZGFu7DR/x4sjnTEhfjXEoLv1C4AdgGHCIjW9wU6HkcWnla\nX7akKlwIWEUP/BFLkcWPpmUrtClhWx9wq1GHFvKAN/qp//VWnv4IfRU6RjmVPOWB\nefvTu/cpsfBHLyp15goOYPboahIdTUTNQIXh4Vid7E1NoKnWZUMu50n3/zAbjSds\nmNmifi4g01MYJ3TVoU2Q01P7NiD3IRmaw72nLmf9cM9/7QMdGn0AEQEAAcLBdgQY\nAQgAKgUCZVTIjAkQDArzE+X9n4AWIQTj5uQ9hMuFLq2wBR0MCvMT5f2fgAIbDAAA\nSUoP/2ExsUoGbxjuZ76QUnYtfzDoz+o218UWd3gZCsBQ6/hGam5kMq+EUEabF3lV\n7QLDyn/1v5sqrkmYg0u5cfjtY3oimCPvr6E0WTuqMIwYl0fdlkmdNttDpMqvCazq\nbzLK5dDVWbh/EYTiEN1xKXM6rlAquYv8I16uWL8QHanMb6yexNmDYhC4fXWqCi+s\n5sXxWrPrd+fGz8CR/fEYahPXj8uY6dwN9DlWyek9QtKW2PsqrkBn5vCOm2IyZW6d\nt/Kn70tYtxMxJND2otk47mpG/Fv3sYK2bTGJ+k/5+E5IrjWqIX2lVB3G1+TCoZ5s\ncc16zls32mOlRh81fTAqcwkDFxICxcOeNHGLt3N+UvoPSUafYKD96rn5mWFao4xb\ncFniaYv2PdqH8HDjvXZXqHypRMXvYMbXXOgydLL+tSUSBpMTd4afjq8x2gNSWOEL\nI1jT5FWbKTKan0ycKi37bSqGHhDjlg4HRGvC3IK0EuVjdX3r+8uIVgFbqLwNhXk4\nGAIL03vl689TQ7/oPW75XCQIevFai0kcJPl6qIRvi9/S/v5EPRy9UDCGY/MPmc5f\nH1an0ebU4I4TlYfBoEUkYYqBDxvxWW0I/Q01rDebcd6mrGw8lW1EiNZlClLwx9Bv\n/+MNnIT9m1f8KeqmweoAgbIQRUI7EkJSzxYN4DNuy2XoKmF9\n=VhyH\n-----END PGP PUBLIC KEY BLOCK-----",
+        "key_id": "0C0AF313E5FD9F80"
+      }
+    ]
+  },
+  "packages": {
+    "darwin_amd64": {
+      "hashes": [
+        "zh:e25265d4e87821d18dc9653a0ce01978a1ae5d363bc01dd273454db1aa0309c7",
+        "h1:BdIx478D4wpFgFeaS+5Bdve1HIlt3Yhsr5hAbUs2rRg="
+      ],
+      "package_size": 4945518
+    },
+    "darwin_arm64": {
+      "hashes": [
+        "zh:5ce03460813954cbebc9f9ad5befbe364d9dc67acb08869f67c1aa634fbf6d6c",
+        "h1:+JAon/4CyriC/c7c77NjJalKrKx6gwwQ7L7rVABWMtA="
+      ],
+      "package_size": 4781117
+    },
+    "linux_386": {
+      "hashes": [
+        "zh:c38c9a295cfae9fb6372523c34b9466cd439d5e2c909b56a788960d387c24320",
+        "h1:Oio8EVe+5LQF7cd7IYcIrXkyKy8nCrBF/X8DQUAgayQ="
+      ],
+      "package_size": 4543480
+    },
+    "linux_amd64": {
+      "hashes": [
+        "zh:40335019c11e5bdb3780301da5197cbc756b4b5ac3d699c52583f1d34e963176",
+        "h1:uQv2oPjJv+ue8bPrVp+So2hHd90UTssnCNajTW554Cw="
+      ],
+      "package_size": 4750928
+    },
+    "linux_arm": {
+      "hashes": [
+        "zh:42356e687656fc8ec1f230f786f830f344e64419552ec483e2bc79bd4b7cf1e8",
+        "h1:+s8zqab9SoQhfWDJVRtv9b2pJRyQlZu88NHK0X4bODQ="
+      ],
+      "package_size": 4481884
+    },
+    "linux_arm64": {
+      "hashes": [
+        "zh:91a76f371815a130735c8fcb6196804d878aebcc67b4c3b73571d2063336ffd8",
+        "h1:9WdPl8ujc45POfiiCzcX60bljY744neqTGlK24VMhgk="
+      ],
+      "package_size": 4368837
+    },
+    "windows_386": {
+      "hashes": [
+        "zh:658ea3e3e7ecc964bdbd08ecde63f3d79f298bab9922b29a6526ba941a4d403a",
+        "h1:K7QNZz/LCsVhvHLA8orqjfVr+qYh4QAPhMi+n9Es6js="
+      ],
+      "package_size": 4669934
+    },
+    "windows_amd64": {
+      "hashes": [
+        "zh:80fd03335f793dc54302dd53da98c91fd94f182bcacf13457bed1a99ecffbc1a",
+        "h1:uvf7c5e8N7A0k9dqF2pLbbbPTAHIwUoM885CHCS717E="
+      ],
+      "package_size": 4763231
+    },
+    "windows_arm": {
+      "hashes": [
+        "zh:c146fc0291b7f6284fe4d54ce6aaece6957e9acc93fc572dd505dfd8bcad3e6c",
+        "h1:8sG3Tdnsk1STHIKaFORkb9EKaR6eNkzX1MCqWZLo6uY="
+      ],
+      "package_size": 4538273
+    },
+    "windows_arm64": {
+      "hashes": [
+        "zh:68c06703bc57f9c882bfedda6f3047775f0d367093d00efb040800c798b8a613",
+        "h1:ckcDeFlUdHEPosRUSxqyCzVdZLh9mrM4ebhygf6c3SA="
+      ],
+      "package_size": 4381068
+    }
   }
 }
 `


### PR DESCRIPTION
Starting with OpenTofu v1.12, the OpenTofu Registry now returns both the zh hash and the precomputed h1 hash, so fetching only the metadata allows us to skip downloading the provider’s binary. If the platform is omitted, we assume that the registry metadata returns the h1 hash values for all platforms.

Previously, the `lock` command required the `--platform` flag, so this is not a breaking change for the CLI. However, it is a breaking change for the Go package.