### PR TITLE
Support optional module/provider source hostname prefix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
         opentofu:
         - 1.12.3
         - 1.11.11
-        - 1.6.3
+        - 1.9.1
     env:
       OPENTOFU_VERSION: ${{ matrix.opentofu }}
       TFUPDATE_EXEC_PATH: tofu

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,9 @@
 ARG TERRAFORM_VERSION=latest
+ARG OPENTOFU_VERSION=1
+
 FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
 
-FROM alpine:3.23 AS opentofu
-ARG OPENTOFU_VERSION=latest
-ADD https://get.opentofu.org/install-opentofu.sh /install-opentofu.sh
-RUN chmod +x /install-opentofu.sh
-RUN apk add gpg gpg-agent
-RUN ./install-opentofu.sh --install-method standalone --opentofu-version $OPENTOFU_VERSION --install-path /usr/local/bin --symlink-path -
+FROM ghcr.io/opentofu/opentofu:$OPENTOFU_VERSION-minimal AS opentofu
 
 # tfupdate
 FROM golang:1.26-alpine3.23 AS tfupdate

--- a/README.md
+++ b/README.md
@@ -341,11 +341,13 @@ Arguments
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
                        - tfregistryModule:
-                         namespace/name/provider
+                         [hostname/]namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                              registry.opentofu.org/terraform-aws-modules/vpc/aws
                        - tfregistryProvider:
-                         namespace/type
+                         [hostname/]namespace/type
                          e.g. hashicorp/aws
+                              registry.opentofu.org/hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.
@@ -378,11 +380,13 @@ Arguments
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
                        - tfregistryModule:
-                         namespace/name/provider
+                         [hostname/]namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                              registry.opentofu.org/terraform-aws-modules/vpc/aws
                        - tfregistryProvider:
-                         namespace/type
+                         [hostname/]namespace/type
                          e.g. hashicorp/aws
+                              registry.opentofu.org/hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.

--- a/command/release_latest.go
+++ b/command/release_latest.go
@@ -62,11 +62,13 @@ Arguments
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
                        - tfregistryModule:
-                         namespace/name/provider
+                         [hostname/]namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                              registry.opentofu.org/terraform-aws-modules/vpc/aws
                        - tfregistryProvider:
-                         namespace/type
+                         [hostname/]namespace/type
                          e.g. hashicorp/aws
+                              registry.opentofu.org/hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.

--- a/command/release_list.go
+++ b/command/release_list.go
@@ -66,11 +66,13 @@ Arguments
                          owner/repo
                          e.g. terraform-providers/terraform-provider-aws
                        - tfregistryModule:
-                         namespace/name/provider
+                         [hostname/]namespace/name/provider
                          e.g. terraform-aws-modules/vpc/aws
+                              registry.opentofu.org/terraform-aws-modules/vpc/aws
                        - tfregistryProvider:
-                         namespace/type
+                         [hostname/]namespace/type
                          e.g. hashicorp/aws
+                              registry.opentofu.org/hashicorp/aws
 
 Options:
   -s  --source-type  A type of release data source.

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./Dockerfile.dev
       args:
         TERRAFORM_VERSION: ${TERRAFORM_VERSION:-latest}
-        OPENTOFU_VERSION: ${OPENTOFU_VERSION:-latest}
+        OPENTOFU_VERSION: ${OPENTOFU_VERSION:-1}
     volumes:
       - ".:/work"
     environment:

--- a/release/tfregistry.go
+++ b/release/tfregistry.go
@@ -28,8 +28,16 @@ var _ Release = (*TFRegistryModuleRelease)(nil)
 
 // NewTFRegistryModuleRelease is a factory method which returns an TFRegistryModuleRelease instance.
 func NewTFRegistryModuleRelease(source string, config tfregistry.Config) (Release, error) {
-	s := strings.SplitN(source, "/", 3)
-	if len(s) != 3 {
+	s := strings.Split(source, "/")
+
+	switch len(s) {
+	case 3:
+		// NAMESPACE/NAME/PROVIDER
+	case 4:
+		// HOSTNAME/NAMESPACE/NAME/PROVIDER
+		config.BaseURL = fmt.Sprintf("https://%s/", s[0])
+		s = s[1:]
+	default:
 		return nil, fmt.Errorf("failed to parse source: %s", source)
 	}
 
@@ -89,8 +97,16 @@ var _ Release = (*TFRegistryProviderRelease)(nil)
 
 // NewTFRegistryProviderRelease is a factory method which returns an TFRegistryProviderRelease instance.
 func NewTFRegistryProviderRelease(source string, config tfregistry.Config) (Release, error) {
-	s := strings.SplitN(source, "/", 2)
-	if len(s) != 2 {
+	s := strings.Split(source, "/")
+
+	switch len(s) {
+	case 2:
+		// NAMESPACE/TYPE
+	case 3:
+		// HOSTNAME/NAMESPACE/TYPE
+		config.BaseURL = fmt.Sprintf("https://%s/", s[0])
+		s = s[1:]
+	default:
 		return nil, fmt.Errorf("failed to parse source: %s", source)
 	}
 

--- a/release/tfregistry_test.go
+++ b/release/tfregistry_test.go
@@ -37,6 +37,7 @@ func TestNewTFRegistryModuleRelease(t *testing.T) {
 		namespace string
 		name      string
 		provider  string
+		baseURL   string
 		ok        bool
 	}{
 		{
@@ -44,10 +45,26 @@ func TestNewTFRegistryModuleRelease(t *testing.T) {
 			namespace: "hoge",
 			name:      "fuga",
 			provider:  "piyo",
+			baseURL:   "https://registry.terraform.io/",
+			ok:        true,
+		},
+		{
+			source:    "registry.opentofu.org/hoge/fuga/piyo",
+			namespace: "hoge",
+			name:      "fuga",
+			provider:  "piyo",
+			baseURL:   "https://registry.opentofu.org/",
 			ok:        true,
 		},
 		{
 			source:    "hoge",
+			namespace: "",
+			name:      "",
+			provider:  "",
+			ok:        false,
+		},
+		{
+			source:    "hoge/fuga/piyo/hogera/hogehoge",
 			namespace: "",
 			name:      "",
 			provider:  "",
@@ -73,6 +90,10 @@ func TestNewTFRegistryModuleRelease(t *testing.T) {
 			if r.namespace != tc.namespace || r.name != tc.name || r.provider != tc.provider {
 				t.Errorf("NewTFRegistryModuleRelease() with source = %s returns (%s, %s, %s), but want (%s, %s, %s)", tc.source, r.namespace, r.name, r.provider, tc.namespace, tc.name, tc.provider)
 			}
+
+			if baseURL := r.api.(*tfregistry.Client).BaseURL.String(); baseURL != tc.baseURL {
+				t.Errorf("NewTFRegistryModuleRelease() with source = %s returns BaseURL = %s, but want = %s", tc.source, baseURL, tc.baseURL)
+			}
 		}
 	}
 }
@@ -82,16 +103,31 @@ func TestNewTFRegistryProviderRelease(t *testing.T) {
 		source       string
 		namespace    string
 		providerType string
+		baseURL      string
 		ok           bool
 	}{
 		{
 			source:       "hoge/piyo",
 			namespace:    "hoge",
 			providerType: "piyo",
+			baseURL:      "https://registry.terraform.io/",
+			ok:           true,
+		},
+		{
+			source:       "registry.opentofu.org/fuga/piyo",
+			namespace:    "fuga",
+			providerType: "piyo",
+			baseURL:      "https://registry.opentofu.org/",
 			ok:           true,
 		},
 		{
 			source:       "hoge",
+			namespace:    "",
+			providerType: "",
+			ok:           false,
+		},
+		{
+			source:       "hoge/fuga/piyo/hogera",
 			namespace:    "",
 			providerType: "",
 			ok:           false,
@@ -115,6 +151,10 @@ func TestNewTFRegistryProviderRelease(t *testing.T) {
 
 			if r.namespace != tc.namespace || r.providerType != tc.providerType {
 				t.Errorf("NewTFRegistryProviderRelease() with source = %s returns (%s, %s), but want (%s, %s)", tc.source, r.namespace, r.providerType, tc.namespace, tc.providerType)
+			}
+
+			if baseURL := r.api.(*tfregistry.Client).BaseURL.String(); baseURL != tc.baseURL {
+				t.Errorf("NewTFRegistryProviderRelease() with source = %s returns BaseURL = %s, but want = %s", tc.source, baseURL, tc.baseURL)
 			}
 		}
 	}


### PR DESCRIPTION
I have a project that uses OpenTofu with all provider and module sources prefixed with `registry.opentofu.org`.
This simple PR adds support for these optional registry hostname prefixes. I know this is already supported with the `TFREGISTRY_BASE_URL` env var but that feels like more of a workaround.

So the following two commands are now equivalent:
```
TFREGISTRY_BASE_URL=https://registry.terraform.io tfupdate release latest -s tfregistryModule terraform-aws-modules/vpc/aws
tfupdate release latest -s tfregistryModule registry.opentofu.org/terraform-aws-modules/vpc/aws
```

This change is based on the official source address documentation [here](https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses) and [here](https://docs.hashicorp.com/terraform/language/modules/sources#terraform-registry).